### PR TITLE
fix(release): unblock musl and Windows native packages

### DIFF
--- a/.github/requirements-zig-linux.txt
+++ b/.github/requirements-zig-linux.txt
@@ -1,0 +1,3 @@
+ziglang==0.14.1 \
+  --hash=sha256:6eb9d4d759b292c83810dbee2e9e8e3fbfbf01d864e6e9811bae711fd74e1c2f \
+  --hash=sha256:7994b27f3cbfcedea43f9b7552e38b45857bdf0e9a45065474092dd74e7048cf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Verify pinned cargo-zigbuild for musl targets
         if: matrix.musl
         shell: bash
-        run: test "$(cargo zigbuild --version)" = "cargo-zigbuild ${CARGO_ZIGBUILD_VERSION}"
+        run: test "$(cargo-zigbuild --version)" = "cargo-zigbuild ${CARGO_ZIGBUILD_VERSION}"
 
       - name: Build target N-API binary
         if: ${{ !matrix.musl }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ env:
   # Make every native artifact self-identify the exact release source revision.
   FICT_COMPILER_BUILD_REVISION: ${{ github.sha }}
   CARGO_AUDIT_VERSION: 0.22.2
+  CARGO_ZIGBUILD_VERSION: 0.23.0
+  ZIG_VERSION: 0.14.1
 
 jobs:
   native-matrix:
@@ -72,17 +74,49 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Install musl linker
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.rustTarget }}
+
+      - name: Install pinned Zig for musl targets
         if: matrix.musl
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes musl-tools
+          python3 -m venv "${RUNNER_TEMP}/fict-zig"
+          "${RUNNER_TEMP}/fict-zig/bin/python" -m pip install \
+            --disable-pip-version-check \
+            --require-hashes \
+            --requirement .github/requirements-zig-linux.txt
+          test "$("${RUNNER_TEMP}/fict-zig/bin/python" -m ziglang version)" = "${ZIG_VERSION}"
+
+      - name: Cache pinned cargo-zigbuild for musl targets
+        if: matrix.musl
+        id: cargo-zigbuild-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-zigbuild
+          key: cargo-zigbuild-${{ runner.os }}-${{ runner.arch }}-${{ env.CARGO_ZIGBUILD_VERSION }}
+
+      - name: Install pinned cargo-zigbuild for musl targets
+        if: ${{ matrix.musl && steps.cargo-zigbuild-cache.outputs.cache-hit != 'true' }}
+        run: cargo install cargo-zigbuild --version "${CARGO_ZIGBUILD_VERSION}" --locked
+
+      - name: Verify pinned cargo-zigbuild for musl targets
+        if: matrix.musl
+        shell: bash
+        run: test "$(cargo zigbuild --version)" = "cargo-zigbuild ${CARGO_ZIGBUILD_VERSION}"
 
       - name: Build target N-API binary
-        run: |
-          rustup target add ${{ matrix.rustTarget }}
-          cargo build --release -p fict-compiler-napi --target ${{ matrix.rustTarget }}
+        if: ${{ !matrix.musl }}
+        run: cargo build --release -p fict-compiler-napi --target ${{ matrix.rustTarget }}
+
+      - name: Build target N-API binary with Zig
+        if: matrix.musl
+        shell: bash
+        env:
+          CARGO_ZIGBUILD_PYTHON_PATH: ${{ runner.temp }}/fict-zig/bin/python
+          # Rust's musl targets default to static CRT, which does not support cdylib output.
+          RUSTFLAGS: '-C target-feature=-crt-static'
+        run: cargo zigbuild --release -p fict-compiler-napi --target ${{ matrix.rustTarget }}
 
       - name: Assemble checksummed platform tarball
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 9.1.1
+
       - uses: actions/setup-node@v5
         with:
           node-version: 24

--- a/crates/fict-compiler/build.rs
+++ b/crates/fict-compiler/build.rs
@@ -8,6 +8,9 @@ use std::{
 
 use sha2::{Digest, Sha256};
 
+#[path = "src/build_id_input.rs"]
+mod build_id_input;
+
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-env-changed=FICT_COMPILER_BUILD_REVISION");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PREVIEW");
@@ -61,7 +64,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rerun-if-changed={}", input.display());
         hasher.update(normalize_relative_path(relative).as_bytes());
         hasher.update(b"\0");
-        hasher.update(fs::read(&input)?);
+        let source = fs::read(&input)?;
+        hasher.update(build_id_input::normalize_source_bytes(&source).as_ref());
         hasher.update(b"\0");
     }
 

--- a/crates/fict-compiler/src/build_id_input.rs
+++ b/crates/fict-compiler/src/build_id_input.rs
@@ -1,0 +1,39 @@
+use std::borrow::Cow;
+
+pub(crate) fn normalize_source_bytes(bytes: &[u8]) -> Cow<'_, [u8]> {
+    if !bytes.windows(2).any(|pair| pair == b"\r\n") {
+        return Cow::Borrowed(bytes);
+    }
+
+    let mut normalized = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\r' && bytes.get(index + 1) == Some(&b'\n') {
+            normalized.push(b'\n');
+            index += 2;
+        } else {
+            normalized.push(bytes[index]);
+            index += 1;
+        }
+    }
+    Cow::Owned(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_source_bytes;
+
+    #[test]
+    fn normalizes_windows_line_endings_for_cross_platform_build_ids() {
+        assert_eq!(
+            normalize_source_bytes(b"Cargo.lock\r\ncrate source\r\n").as_ref(),
+            b"Cargo.lock\ncrate source\n",
+        );
+    }
+
+    #[test]
+    fn preserves_lf_and_lone_carriage_returns() {
+        let input = b"line one\nline two\rline three\n";
+        assert_eq!(normalize_source_bytes(input).as_ref(), input);
+    }
+}

--- a/crates/fict-compiler/src/lib.rs
+++ b/crates/fict-compiler/src/lib.rs
@@ -6,6 +6,8 @@
 //! filesystem, network, Node, N-API, or bundler state.
 
 mod analysis;
+#[cfg(test)]
+mod build_id_input;
 mod control_flow_diagnostics;
 mod diagnostic_policy;
 mod metadata_analysis;

--- a/scripts/native-compiler-package-smoke.mjs
+++ b/scripts/native-compiler-package-smoke.mjs
@@ -25,7 +25,8 @@ import {
   verifyNativeBundle,
 } from './native-compiler-packages.mjs'
 
-const packageManager = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const packageManager = 'pnpm'
+const windowsPackageManagerCommand = /^(?:npm|pnpm)(?:\.cmd)?$/i
 
 function parseArguments(args) {
   const options = {}
@@ -59,8 +60,30 @@ function detectHostTarget() {
   return definition
 }
 
+export function packageCommandInvocation(
+  command,
+  args,
+  { platform = process.platform, commandInterpreter = process.env.ComSpec } = {},
+) {
+  if (typeof command !== 'string' || command.length === 0) {
+    throw new TypeError('Package command must be a non-empty string')
+  }
+  if (!Array.isArray(args) || args.some(argument => typeof argument !== 'string')) {
+    throw new TypeError('Package command arguments must be strings')
+  }
+  if (platform === 'win32' && windowsPackageManagerCommand.test(command)) {
+    const commandFile = command.toLowerCase().endsWith('.cmd') ? command : `${command}.cmd`
+    return {
+      command: commandInterpreter || 'cmd.exe',
+      args: ['/d', '/s', '/c', commandFile, ...args],
+    }
+  }
+  return { command, args: [...args] }
+}
+
 function run(command, args, options = {}) {
-  const result = spawnSync(command, args, {
+  const invocation = packageCommandInvocation(command, args)
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: options.cwd ?? repositoryRoot,
     encoding: 'utf8',
     env: { ...process.env, ...options.env },

--- a/scripts/native-compiler-package-smoke.mjs
+++ b/scripts/native-compiler-package-smoke.mjs
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   rmSync,
   writeFileSync,
@@ -90,8 +91,13 @@ function packCompilerFacade(packsDirectory) {
   return path.join(packsDirectory, created[0])
 }
 
-function relativeFileDependency(fromDirectory, filePath) {
-  return `file:${path.relative(fromDirectory, filePath).split(path.sep).join('/')}`
+export function relativeFileDependency(fromDirectory, filePath) {
+  const canonicalFromDirectory = realpathSync(fromDirectory)
+  const canonicalFilePath = realpathSync(filePath)
+  return `file:${path
+    .relative(canonicalFromDirectory, canonicalFilePath)
+    .split(path.sep)
+    .join('/')}`
 }
 
 function packResolutionOnlyNativePackages(tempRoot, packsDirectory, host, hostTarball) {

--- a/scripts/native-compiler-packages.mjs
+++ b/scripts/native-compiler-packages.mjs
@@ -519,13 +519,33 @@ function parseNpmPackOutput(output) {
   return entries[0]
 }
 
+export function npmInvocation(
+  args,
+  { platform = process.platform, commandInterpreter = process.env.ComSpec } = {},
+) {
+  if (!Array.isArray(args) || args.some(argument => typeof argument !== 'string')) {
+    throw new TypeError('npm invocation arguments must be strings')
+  }
+  return platform === 'win32'
+    ? {
+        command: commandInterpreter || 'cmd.exe',
+        args: ['/d', '/s', '/c', 'npm.cmd', ...args],
+      }
+    : { command: 'npm', args: [...args] }
+}
+
 export function packNativePackage({ target, packageDirectory, outputDirectory }) {
   const artifact = verifyNativePackageArtifact({ target, packageDirectory })
   const destination = path.resolve(outputDirectory)
   mkdirSync(destination, { recursive: true })
-  const packed = parseNpmPackOutput(
-    run('npm', ['pack', artifact.directory, '--json', '--pack-destination', destination]),
-  )
+  const invocation = npmInvocation([
+    'pack',
+    artifact.directory,
+    '--json',
+    '--pack-destination',
+    destination,
+  ])
+  const packed = parseNpmPackOutput(run(invocation.command, invocation.args))
   const requiredEntries = new Set([
     'package.json',
     NATIVE_COMPILER_BINARY,

--- a/scripts/native-compiler-packages.test.mjs
+++ b/scripts/native-compiler-packages.test.mjs
@@ -15,7 +15,10 @@ import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { relativeFileDependency } from './native-compiler-package-smoke.mjs'
+import {
+  packageCommandInvocation,
+  relativeFileDependency,
+} from './native-compiler-package-smoke.mjs'
 import {
   NATIVE_COMPILER_NODE_LANES,
   NATIVE_COMPILER_TARGETS,
@@ -354,6 +357,37 @@ test('canonicalizes symlinked temp roots before creating local package dependenc
   } finally {
     rmSync(tempRoot, { recursive: true, force: true })
   }
+})
+
+test('invokes smoke package managers through the Windows command interpreter', () => {
+  const args = ['--dir', 'D:\\a\\fict package', 'pack']
+  const commandInterpreter = 'C:\\Windows\\System32\\cmd.exe'
+  assert.deepEqual(
+    packageCommandInvocation('pnpm', args, { platform: 'win32', commandInterpreter }),
+    {
+      command: commandInterpreter,
+      args: ['/d', '/s', '/c', 'pnpm.cmd', ...args],
+    },
+  )
+  assert.deepEqual(
+    packageCommandInvocation('npm.cmd', args, { platform: 'win32', commandInterpreter }),
+    {
+      command: commandInterpreter,
+      args: ['/d', '/s', '/c', 'npm.cmd', ...args],
+    },
+  )
+  assert.deepEqual(packageCommandInvocation('node.exe', args, { platform: 'win32' }), {
+    command: 'node.exe',
+    args,
+  })
+  assert.deepEqual(packageCommandInvocation('pnpm', args, { platform: 'linux' }), {
+    command: 'pnpm',
+    args,
+  })
+  assert.throws(
+    () => packageCommandInvocation('pnpm', ['install', 1], { platform: 'win32' }),
+    /must be strings/,
+  )
 })
 
 test('keeps facade optional dependencies, package manifests, allowlist, and Changesets aligned', () => {

--- a/scripts/native-compiler-packages.test.mjs
+++ b/scripts/native-compiler-packages.test.mjs
@@ -1,12 +1,21 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
+import { relativeFileDependency } from './native-compiler-package-smoke.mjs'
 import {
   NATIVE_COMPILER_NODE_LANES,
   NATIVE_COMPILER_TARGETS,
@@ -320,6 +329,31 @@ test('invokes npm through the Windows command interpreter for native package ass
     args,
   })
   assert.throws(() => npmInvocation(['pack', 1], { platform: 'win32' }), /must be strings/)
+})
+
+test('canonicalizes symlinked temp roots before creating local package dependencies', () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'fict-native-file-dependency-test-'))
+  try {
+    const physicalTempRoot = path.join(tempRoot, 'private', 'var')
+    const aliasedTempRoot = path.join(tempRoot, 'var')
+    const physicalConsumer = path.join(physicalTempRoot, 'folders', 'consumer')
+    const aliasedConsumer = path.join(aliasedTempRoot, 'folders', 'consumer')
+    const tarball = path.join(tempRoot, 'Users', 'runner', 'native-package.tgz')
+    mkdirSync(physicalConsumer, { recursive: true })
+    mkdirSync(path.dirname(tarball), { recursive: true })
+    writeFileSync(tarball, 'native package')
+    symlinkSync(physicalTempRoot, aliasedTempRoot, 'dir')
+
+    const dependency = relativeFileDependency(aliasedConsumer, tarball)
+    const resolvedByPackageManager = path.resolve(
+      realpathSync(aliasedConsumer),
+      dependency.slice('file:'.length),
+    )
+
+    assert.equal(realpathSync(resolvedByPackageManager), realpathSync(tarball))
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
 })
 
 test('keeps facade optional dependencies, package manifests, allowlist, and Changesets aligned', () => {

--- a/scripts/native-compiler-packages.test.mjs
+++ b/scripts/native-compiler-packages.test.mjs
@@ -19,6 +19,7 @@ import {
   nativeHostTarget,
   nativeNodeVersionMatchesLane,
   nativeRuntimeMatrix,
+  npmInvocation,
   validateNativePackageConfiguration,
   validateNativeRuntimeEvidenceMatrix,
   validateOxcVersionAlignment,
@@ -300,6 +301,25 @@ test('maps supported development hosts to their release package target', () => {
     () => nativeHostTarget({ platform: 'freebsd', arch: 'x64' }),
     /Unsupported Fict native compiler host/,
   )
+})
+
+test('invokes npm through the Windows command interpreter for native package assembly', () => {
+  const args = ['pack', 'D:\\a\\fict package', '--json']
+  assert.deepEqual(
+    npmInvocation(args, {
+      platform: 'win32',
+      commandInterpreter: 'C:\\Windows\\System32\\cmd.exe',
+    }),
+    {
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'npm.cmd', ...args],
+    },
+  )
+  assert.deepEqual(npmInvocation(args, { platform: 'linux' }), {
+    command: 'npm',
+    args,
+  })
+  assert.throws(() => npmInvocation(['pack', 1], { platform: 'win32' }), /must be strings/)
 })
 
 test('keeps facade optional dependencies, package manifests, allowlist, and Changesets aligned', () => {

--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -232,8 +232,12 @@ test('release aggregates and certifies all revision-bound native runtime evidenc
 
   const certificationSource = releaseWorkflow.slice(certificationJob, releaseJob)
   const releaseSource = releaseWorkflow.slice(releaseJob)
+  const certificationPnpmSetup = certificationSource.indexOf('uses: pnpm/action-setup@v5')
+  const certificationNodeSetup = certificationSource.indexOf('uses: actions/setup-node@v5')
   assert.match(certificationSource, /needs: \[native-build, native-runtime\]/)
   assert.doesNotMatch(certificationSource, /github\.event_name == 'push'/)
+  assert.ok(certificationPnpmSetup >= 0 && certificationPnpmSetup < certificationNodeSetup)
+  assert.match(certificationSource, /uses: pnpm\/action-setup@v5[\s\S]*?version: 9\.1\.1/)
   assert.match(releaseSource, /needs: native-certification/)
   assert.doesNotMatch(releaseSource, /Download all native runtime evidence/)
 })

--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -36,6 +36,10 @@ const releaseWorkflow = readFileSync(
   new URL('../.github/workflows/release.yml', import.meta.url),
   'utf8',
 )
+const zigRequirements = readFileSync(
+  new URL('../.github/requirements-zig-linux.txt', import.meta.url),
+  'utf8',
+)
 const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8')
 const turboConfig = JSON.parse(readFileSync(new URL('../turbo.json', import.meta.url), 'utf8'))
 const ssrPackage = JSON.parse(
@@ -121,6 +125,43 @@ test('CI and release use Node 24-compatible action majors', () => {
   }
 
   assert.deepEqual([...seen].sort(), [...minimumMajors.keys()].sort())
+})
+
+test('musl native releases use a pinned Zig cdylib build path', () => {
+  const nativeBuildStart = releaseWorkflow.indexOf('\n  native-build:')
+  const nativeRuntimeStart = releaseWorkflow.indexOf('\n  native-runtime:')
+  assert.ok(nativeBuildStart >= 0 && nativeBuildStart < nativeRuntimeStart)
+
+  const nativeBuild = releaseWorkflow.slice(nativeBuildStart, nativeRuntimeStart)
+  assert.match(releaseWorkflow, /^  CARGO_ZIGBUILD_VERSION: 0\.23\.0$/m)
+  assert.match(releaseWorkflow, /^  ZIG_VERSION: 0\.14\.1$/m)
+  assert.match(
+    zigRequirements,
+    /^ziglang==0\.14\.1 \\\n\s+--hash=sha256:[a-f0-9]{64} \\\n\s+--hash=sha256:[a-f0-9]{64}\n$/,
+  )
+  assert.match(
+    nativeBuild,
+    /python3 -m venv "\$\{RUNNER_TEMP\}\/fict-zig"[\s\S]*?--require-hashes[\s\S]*?--requirement \.github\/requirements-zig-linux\.txt/,
+  )
+  assert.match(
+    nativeBuild,
+    /test "\$\("\$\{RUNNER_TEMP\}\/fict-zig\/bin\/python" -m ziglang version\)" = "\$\{ZIG_VERSION\}"/,
+  )
+  assert.match(nativeBuild, /path: ~\/\.cargo\/bin\/cargo-zigbuild/)
+  assert.match(
+    nativeBuild,
+    /cargo install cargo-zigbuild --version "\$\{CARGO_ZIGBUILD_VERSION\}" --locked/,
+  )
+  assert.match(
+    nativeBuild,
+    /test "\$\(cargo zigbuild --version\)" = "cargo-zigbuild \$\{CARGO_ZIGBUILD_VERSION\}"/,
+  )
+  assert.match(nativeBuild, /name: Build target N-API binary\n\s+if: \$\{\{ !matrix\.musl \}\}/)
+  assert.match(
+    nativeBuild,
+    /name: Build target N-API binary with Zig[\s\S]*?CARGO_ZIGBUILD_PYTHON_PATH: \$\{\{ runner\.temp \}\}\/fict-zig\/bin\/python[\s\S]*?RUSTFLAGS: '-C target-feature=-crt-static'[\s\S]*?cargo zigbuild --release -p fict-compiler-napi --target \$\{\{ matrix\.rustTarget \}\}/,
+  )
+  assert.doesNotMatch(nativeBuild, /musl-tools|Install musl linker|mlugg\/setup-zig/)
 })
 
 test('Babel preset deprecation verification builds its compiler dependency first', () => {

--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -154,7 +154,7 @@ test('musl native releases use a pinned Zig cdylib build path', () => {
   )
   assert.match(
     nativeBuild,
-    /test "\$\(cargo zigbuild --version\)" = "cargo-zigbuild \$\{CARGO_ZIGBUILD_VERSION\}"/,
+    /test "\$\(cargo-zigbuild --version\)" = "cargo-zigbuild \$\{CARGO_ZIGBUILD_VERSION\}"/,
   )
   assert.match(nativeBuild, /name: Build target N-API binary\n\s+if: \$\{\{ !matrix\.musl \}\}/)
   assert.match(


### PR DESCRIPTION
## Summary

- build the x64 and arm64 musl N-API `cdylib` targets with pinned `cargo-zigbuild 0.23.0` and `Zig 0.14.1`
- install Zig from hash-locked platform wheels without adding a Node 20 GitHub Action
- invoke `npm pack` through `cmd.exe` on Windows while preserving direct execution elsewhere
- add release-workflow and cross-platform native-package contract tests

## Root cause

Manual release run [29342130119](https://github.com/fictjs/fict/actions/runs/29342130119) reached the authentic 8-target build matrix and exposed two independent portability defects:

1. Rust 1.97's musl targets default to static CRT and therefore do not advertise `cdylib` output.
2. Both Windows binaries compiled successfully, but package assembly failed with `spawnSync npm ENOENT` because `npm.cmd` requires the Windows command interpreter.

The musl-only path now follows cargo-zigbuild/NAPI-RS guidance and sets `-C target-feature=-crt-static`; the six non-musl compile paths remain unchanged. Native package assembly now uses the Node-documented `cmd.exe /d /s /c npm.cmd` invocation only on Windows.

## Verification

- `pnpm test:release-verification` (30/30)
- `pnpm test:compiler:native-package-contract` (15/15)
- `pnpm test:compiler:native-packages` (14/14 plus native host smoke before the Windows follow-up)
- `pnpm test:release-publish-plan` (10/10)
- Prettier, YAML parse, and `git diff --check`
