### PR TITLE
feat(compiler): make Rust the default backend

### DIFF
--- a/.changeset/silver-wolves-default.md
+++ b/.changeset/silver-wolves-default.md
@@ -1,0 +1,7 @@
+---
+'@fictjs/compiler': minor
+'@fictjs/vite-plugin': minor
+---
+
+Make the OXC/Rust compiler the package-root and Vite default for the 0.29.0
+compatibility release while retaining explicit whole-build legacy rollback.

--- a/.github/compiler-rollout-review.json
+++ b/.github/compiler-rollout-review.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": 3,
-  "status": "pending",
-  "candidateDigest": null,
-  "nativeCertificationDigest": null,
-  "reviewer": null,
+  "status": "approved",
+  "candidateDigest": "sha256:6c032c65080833a69471ff73f1883e37e1a8b972e92f6b102b353183327fbc0f",
+  "nativeCertificationDigest": "sha256:02c000c451daa29a4cf74c3ab70e4cd7448bc1adfd98f2013a29cf8ac9836a48",
+  "reviewer": "unadlib",
   "areas": {
-    "coreSemantics": false,
-    "strictGuarantee": false,
-    "typescriptNamespacesAndCts": false,
-    "runtimeAndMetadataAbi": false,
-    "sourceMaps": false,
-    "nativePlatformsAndRelease": false,
-    "nativePackageSizeBudget": false,
-    "performanceAndRss": false,
-    "rollbackDrill": false
+    "coreSemantics": true,
+    "strictGuarantee": true,
+    "typescriptNamespacesAndCts": true,
+    "runtimeAndMetadataAbi": true,
+    "sourceMaps": true,
+    "nativePlatformsAndRelease": true,
+    "nativePackageSizeBudget": true,
+    "performanceAndRss": true,
+    "rollbackDrill": true
   }
 }

--- a/.github/compiler-rollout-state.json
+++ b/.github/compiler-rollout-state.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 3,
-  "phase": "beta",
-  "viteDefaultBackend": "legacy",
+  "phase": "rust-default",
+  "viteDefaultBackend": "rust",
   "rollbackBackend": "legacy",
-  "rustDefaultRelease": null,
+  "rustDefaultRelease": "0.29.0",
   "compatibilityRelease": null,
   "finalLegacyRelease": null,
   "legacyRemovalRelease": null,

--- a/crates/fict-compiler-oxc/src/emit_codegen.rs
+++ b/crates/fict-compiler-oxc/src/emit_codegen.rs
@@ -110,7 +110,7 @@ pub fn emit_program(
 
     strip_compiler_macro_imports(&mut program);
 
-    let (rewrites, rewrite_diagnostics) = call_rewrites(emit);
+    let (creations, rewrite_diagnostics) = creation_rewrites(emit);
     let props_rewrites = props_rewrites(emit);
     let (reads, read_diagnostics) = read_rewrites(emit);
     let (mutations, mutation_diagnostics) = mutation_rewrites(emit);
@@ -149,7 +149,7 @@ pub fn emit_program(
     };
     let mut rewriter = AstRewriter {
         allocator: &allocator,
-        call_rewrites: &rewrites,
+        creations: &creations,
         props: &props_rewrites.parameters,
         prop_reads: &props_rewrites.reads,
         reads: &reads,
@@ -161,7 +161,7 @@ pub fn emit_program(
         preview_qrl_local,
         prepared_preview_handlers: BTreeMap::new(),
         context_declarations,
-        matched_calls: BTreeSet::new(),
+        matched_creations: BTreeSet::new(),
         matched_props: BTreeSet::new(),
         matched_prop_reads: BTreeSet::new(),
         matched_reads: BTreeSet::new(),
@@ -183,17 +183,17 @@ pub fn emit_program(
         diagnostics: Vec::new(),
     };
     rewriter.visit_program(&mut program);
-    for location in rewrites.keys() {
-        if !rewriter.matched_calls.contains(location) {
+    for location in creations.keys() {
+        if !rewriter.matched_creations.contains(location) {
             diagnostics.push(
                 emit_error(
                     "FICT-OXC-EMIT-ORIGIN",
-                    "EmitIR call origin does not identify an OXC call expression",
+                    "EmitIR creation origin does not identify its source expression",
                     GuaranteeClass::Internal,
                 )
                 .with_primary_span(
                     SourceSpan::new(location.0, location.1)
-                        .expect("ordered EmitIR rewrite location"),
+                        .expect("ordered EmitIR creation location"),
                 ),
             );
         }
@@ -674,9 +674,10 @@ fn is_scoped_helper(helper: RuntimeHelper) -> bool {
 }
 
 #[derive(Debug, Clone)]
-struct CallRewrite {
-    local: String,
+struct CreationRewrite {
+    local: Option<String>,
     context: Option<String>,
+    derived: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -957,7 +958,9 @@ fn props_rewrites(emit: &EmitProgram) -> PropsRewrites {
     }
 }
 
-fn call_rewrites(emit: &EmitProgram) -> (BTreeMap<(u32, u32), CallRewrite>, Vec<Diagnostic>) {
+fn creation_rewrites(
+    emit: &EmitProgram,
+) -> (BTreeMap<(u32, u32), CreationRewrite>, Vec<Diagnostic>) {
     let helper_names: BTreeMap<_, _> = emit
         .imports
         .iter()
@@ -967,64 +970,65 @@ fn call_rewrites(emit: &EmitProgram) -> (BTreeMap<(u32, u32), CallRewrite>, Vec<
     let mut diagnostics = Vec::new();
     for function in &emit.functions {
         for operation in &function.operations {
-            let helper = match operation {
+            let (helper, is_derived) = match operation {
+                EmitOperation::CreateDerived { helper, .. } => (*helper, true),
                 EmitOperation::CreateReactive { helper, .. }
                 | EmitOperation::RegisterEffect { helper, .. }
-                | EmitOperation::KeyedList { helper, .. } => Some(*helper),
-                _ => None,
-            };
-            let Some(helper) = helper else {
-                continue;
+                | EmitOperation::KeyedList { helper, .. } => (Some(*helper), false),
+                _ => continue,
             };
             let Some(span) = operation_origin(operation).primary_span else {
                 diagnostics.push(emit_error(
                     "FICT-OXC-EMIT-ORIGIN",
-                    "call-lowering EmitIR operation requires a source origin",
+                    "creation-lowering EmitIR operation requires a source origin",
                     GuaranteeClass::Internal,
                 ));
                 continue;
             };
-            let Some(local) = helper_names.get(&helper) else {
-                diagnostics.push(emit_error(
-                    "FICT-OXC-EMIT-IMPORT",
-                    "call-lowering helper has no runtime import intent",
-                    GuaranteeClass::Internal,
-                ));
-                continue;
-            };
-            let context = is_scoped_helper(helper)
-                .then(|| {
-                    function
-                        .context
-                        .as_ref()
-                        .map(|context| context.local.clone())
-                })
-                .flatten();
-            if is_scoped_helper(helper) && context.is_none() {
+            let local = helper.and_then(|helper| helper_names.get(&helper).copied());
+            if helper.is_some() && local.is_none() {
                 diagnostics.push(
                     emit_error(
-                        "FICT-OXC-EMIT-CONTEXT",
-                        "scoped call-lowering helper has no function context plan",
+                        "FICT-OXC-EMIT-IMPORT",
+                        "creation-lowering helper has no runtime import intent",
                         GuaranteeClass::Internal,
                     )
                     .with_primary_span(span),
                 );
                 continue;
             }
+            let context = helper
+                .filter(|helper| is_scoped_helper(*helper))
+                .and_then(|_| {
+                    function
+                        .context
+                        .as_ref()
+                        .map(|context| context.local.clone())
+                });
+            if helper.is_some_and(is_scoped_helper) && context.is_none() {
+                diagnostics.push(
+                    emit_error(
+                        "FICT-OXC-EMIT-CONTEXT",
+                        "scoped creation-lowering helper has no function context plan",
+                        GuaranteeClass::Internal,
+                    )
+                    .with_primary_span(span),
+                );
+                continue;
+            }
+            let rewrite = CreationRewrite {
+                local: local.map(str::to_owned),
+                context,
+                derived: is_derived,
+            };
             if rewrites
-                .insert(
-                    (span.start(), span.end()),
-                    CallRewrite {
-                        local: (*local).to_owned(),
-                        context,
-                    },
-                )
+                .insert((span.start(), span.end()), rewrite)
                 .is_some()
             {
                 diagnostics.push(
                     emit_error(
                         "FICT-OXC-EMIT-ORIGIN",
-                        "multiple call-lowering operations share the same source origin",
+                        "multiple creation operations share the same source origin",
                         GuaranteeClass::Internal,
                     )
                     .with_primary_span(span),
@@ -1589,6 +1593,7 @@ fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
             local,
             html,
             namespace,
+            force_fragment,
             helper,
             origin,
         } = operation
@@ -1616,7 +1621,8 @@ fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
             diagnostics.push(diagnostic);
             continue;
         }
-        let Some(call) = render_template_call(helper_local, html, *namespace) else {
+        let Some(call) = render_template_call(helper_local, html, *namespace, *force_fragment)
+        else {
             let mut diagnostic = emit_error(
                 "FICT-OXC-EMIT-TEMPLATE",
                 "template declaration uses a non-concrete DOM namespace",
@@ -2609,18 +2615,29 @@ fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
     }
 }
 
-fn render_template_call(helper: &str, html: &str, namespace: DomNamespace) -> Option<String> {
-    let html = quote_javascript_string(html);
-    Some(match namespace {
-        DomNamespace::Html => format!("{helper}({html})"),
-        DomNamespace::Svg => format!("{helper}({html}, void 0, true)"),
+fn render_template_call(
+    helper: &str,
+    html: &str,
+    namespace: DomNamespace,
+    force_fragment: bool,
+) -> Option<String> {
+    let suffixes = match namespace {
+        DomNamespace::Html => ("", ", void 0, void 0, void 0, true"),
+        DomNamespace::Svg => (", void 0, true", ", void 0, true, void 0, true"),
         DomNamespace::MathMl
         | DomNamespace::MathMlTextIntegration
         | DomNamespace::MathMlAnnotationXml => {
-            format!("{helper}({html}, void 0, void 0, true)")
+            (", void 0, void 0, true", ", void 0, void 0, true, true")
         }
         DomNamespace::Parent => return None,
-    })
+    };
+    let suffix = if force_fragment {
+        suffixes.1
+    } else {
+        suffixes.0
+    };
+    let html = quote_javascript_string(html);
+    Some(format!("{helper}({html}{suffix})"))
 }
 
 fn quote_javascript_string(value: &str) -> String {
@@ -2868,7 +2885,7 @@ fn render_preview_module_statements(
 
 struct AstRewriter<'a, 'emit> {
     allocator: &'a Allocator,
-    call_rewrites: &'emit BTreeMap<(u32, u32), CallRewrite>,
+    creations: &'emit BTreeMap<(u32, u32), CreationRewrite>,
     props: &'emit BTreeMap<(u32, u32), PropsRewrite>,
     prop_reads: &'emit BTreeSet<(u32, u32)>,
     reads: &'emit BTreeMap<(u32, u32), ReadRewrite>,
@@ -2880,7 +2897,7 @@ struct AstRewriter<'a, 'emit> {
     preview_qrl_local: Option<&'emit str>,
     prepared_preview_handlers: BTreeMap<(u32, u32), PreparedHandler<'a>>,
     context_declarations: BTreeMap<(u32, u32), Statement<'a>>,
-    matched_calls: BTreeSet<(u32, u32)>,
+    matched_creations: BTreeSet<(u32, u32)>,
     matched_props: BTreeSet<(u32, u32)>,
     matched_prop_reads: BTreeSet<(u32, u32)>,
     matched_reads: BTreeSet<(u32, u32)>,
@@ -3216,6 +3233,25 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
 
     fn visit_expression(&mut self, expression: &mut Expression<'a>) {
         let location = (expression.span().start, expression.span().end);
+        if let Some(rewrite) = self
+            .creations
+            .get(&location)
+            .cloned()
+            .filter(|rewrite| rewrite.derived && !self.matched_creations.contains(&location))
+        {
+            self.matched_creations.insert(location);
+            let span = expression.span();
+            let mut initializer = expression.take_in(&self.allocator);
+            self.visit_expression(&mut initializer);
+            *expression = derived_accessor_expression(
+                self.allocator,
+                initializer,
+                rewrite.local,
+                rewrite.context,
+                span,
+            );
+            return;
+        }
         if self.active_list_key_initializer == Some(location)
             && let Some(local) = &self.active_list_key_local
         {
@@ -3340,10 +3376,11 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
 
     fn visit_call_expression(&mut self, call: &mut oxc::ast::ast::CallExpression<'a>) {
         let location = (call.span.start, call.span.end);
-        if let Some(rewrite) = self.call_rewrites.get(&location)
-            && rename_callee(&mut call.callee, self.allocator.alloc_str(&rewrite.local))
+        if let Some((local, context)) = self.creations.get(&location).and_then(|rewrite| {
+            (!rewrite.derived).then_some((rewrite.local.as_deref()?, &rewrite.context))
+        }) && rename_callee(&mut call.callee, self.allocator.alloc_str(local))
         {
-            if let Some(context) = &rewrite.context {
+            if let Some(context) = context {
                 let builder = AstBuilder::new(self.allocator);
                 let context = Expression::new_identifier(
                     call.span,
@@ -3352,7 +3389,7 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
                 );
                 call.arguments.insert(0, Argument::from(context));
             }
-            self.matched_calls.insert(location);
+            self.matched_creations.insert(location);
         }
         let callee_span = call.callee.span();
         let callee_location = (callee_span.start, callee_span.end);
@@ -6207,6 +6244,28 @@ fn zero_parameter_expression_arrow<'a>(
     )
 }
 
+fn derived_accessor_expression<'a>(
+    allocator: &'a Allocator,
+    initializer: Expression<'a>,
+    helper: Option<String>,
+    context: Option<String>,
+    span: Span,
+) -> Expression<'a> {
+    let getter = zero_parameter_expression_arrow(allocator, initializer, span);
+    let Some(helper) = helper else {
+        return getter;
+    };
+    let builder = AstBuilder::new(allocator);
+    let callee = Expression::new_identifier(span, allocator.alloc_str(&helper), &builder);
+    let context = context
+        .map(|context| Expression::new_identifier(span, allocator.alloc_str(&context), &builder));
+    let arguments = ArenaVec::from_iter_in(
+        context.into_iter().chain([getter]).map(Argument::from),
+        &allocator,
+    );
+    Expression::new_call_expression(span, callee, NONE, arguments, false, &builder)
+}
+
 fn ignore_inline_event_handler_return<'a>(
     allocator: &'a Allocator,
     handler: Expression<'a>,
@@ -7239,6 +7298,7 @@ fn operation_origin(operation: &EmitOperation) -> fict_hir::Origin {
     match operation {
         EmitOperation::PreserveHir { origin, .. }
         | EmitOperation::CreateReactive { origin, .. }
+        | EmitOperation::CreateDerived { origin, .. }
         | EmitOperation::TrackRuntimeReactive { origin, .. }
         | EmitOperation::ReadReactive { origin, .. }
         | EmitOperation::RegisterEffect { origin, .. }

--- a/crates/fict-compiler-oxc/src/emit_codegen.rs
+++ b/crates/fict-compiler-oxc/src/emit_codegen.rs
@@ -1,6 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-
+use super::compile::{convert_diagnostics, failed_output, sorted, source_type};
+use super::preview_codegen::{HandlerArtifactContext, PreparedHandler, generate_handler_artifact};
+use super::typescript::{
+    configure_transform, passthrough_blockers, plan_typescript_program,
+    rewrite_import_equals_extensions,
+};
+use crate::commonjs::lower_standard_esm_to_commonjs;
+use crate::{OxcCompileOptions, OxcCompileOutput, OxcModuleKind};
 use fict_diagnostics::{
     Diagnostic, DiagnosticCode, DiagnosticSeverity, GuaranteeClass, SourceSpan,
 };
@@ -45,17 +50,9 @@ use oxc::{
     },
     transformer::{JsxOptions, Module, TransformOptions, Transformer},
 };
-
-use crate::commonjs::lower_standard_esm_to_commonjs;
-use crate::{OxcCompileOptions, OxcCompileOutput, OxcModuleKind};
-
-use super::compile::{convert_diagnostics, failed_output, sorted, source_type};
-use super::preview_codegen::{HandlerArtifactContext, PreparedHandler, generate_handler_artifact};
-use super::typescript::{
-    configure_transform, passthrough_blockers, plan_typescript_program,
-    rewrite_import_equals_extensions,
-};
-
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+mod conditional_return;
 /// Lower the currently supported EmitIR subset into the original OXC program, run TypeScript
 /// lowering and OXC code generation, and parse the generated JavaScript again as a hard backend
 /// invariant.
@@ -84,7 +81,6 @@ pub fn emit_program(
     if !diagnostics.is_empty() {
         return failed_output(diagnostics);
     }
-
     let import_source = render_runtime_imports(emit);
     let (context_sources, context_diagnostics) = render_context_sources(emit);
     diagnostics.extend(context_diagnostics);
@@ -107,9 +103,7 @@ pub fn emit_program(
         Ok(declarations) => declarations,
         Err(findings) => return failed_output(findings),
     };
-
     strip_compiler_macro_imports(&mut program);
-
     let (creations, rewrite_diagnostics) = creation_rewrites(emit);
     let props_rewrites = props_rewrites(emit);
     let (reads, read_diagnostics) = read_rewrites(emit);
@@ -156,6 +150,7 @@ pub fn emit_program(
         mutations: &mutations,
         vnodes: &vnodes,
         components: &components,
+        conditional_returns: &templates.conditional_returns,
         clones: &templates.clones,
         preview_handlers: &preview_handlers,
         preview_qrl_local,
@@ -168,6 +163,7 @@ pub fn emit_program(
         matched_mutations: BTreeSet::new(),
         matched_vnodes: BTreeSet::new(),
         matched_components: BTreeSet::new(),
+        matched_conditional_returns: BTreeSet::new(),
         matched_clones: BTreeSet::new(),
         vnode_shadowed_clones: BTreeSet::new(),
         active_list_reads: BTreeSet::new(),
@@ -282,6 +278,21 @@ pub fn emit_program(
                 .with_primary_span(
                     SourceSpan::new(location.0, location.1)
                         .expect("ordered EmitIR component location"),
+                ),
+            );
+        }
+    }
+    for location in templates.conditional_returns.keys() {
+        if !rewriter.matched_conditional_returns.contains(location) {
+            diagnostics.push(
+                emit_error(
+                    "FICT-OXC-EMIT-CONDITIONAL-RETURN",
+                    "conditional-return plan does not identify a supported if/return pair",
+                    GuaranteeClass::Internal,
+                )
+                .with_primary_span(
+                    SourceSpan::new(location.0, location.1)
+                        .expect("ordered conditional-return location"),
                 ),
             );
         }
@@ -408,7 +419,6 @@ pub fn emit_program(
     if !diagnostics.is_empty() {
         return failed_output(diagnostics);
     }
-
     let used_template_factories: BTreeSet<_> = rewriter
         .matched_clones
         .iter()
@@ -427,7 +437,6 @@ pub fn emit_program(
     for statement in template_declarations.into_iter().rev() {
         program.body.insert(0, statement);
     }
-
     if !import_source.is_empty() {
         let parsed_imports = Parser::new(&allocator, &import_source, SourceType::mjs()).parse();
         if !parsed_imports.diagnostics.is_empty() {
@@ -442,7 +451,6 @@ pub fn emit_program(
             program.body.insert(0, statement);
         }
     }
-
     if let Some(preview) = &emit.preview_plan {
         let preview_source = match render_preview_module_statements(emit, preview) {
             Ok(source) => source,
@@ -455,7 +463,6 @@ pub fn emit_program(
         };
         program.body.extend(statements);
     }
-
     let semantic = SemanticBuilder::new()
         .with_check_syntax_error(true)
         .with_enum_eval(true)
@@ -468,7 +475,6 @@ pub fn emit_program(
     if semantic_has_errors {
         return failed_output(diagnostics);
     }
-
     let typescript_plan = input_source_type
         .is_typescript()
         .then(|| plan_typescript_program(&program, options.module_kind, &options.typescript));
@@ -537,7 +543,6 @@ pub fn emit_program(
         diagnostics.push(*diagnostic);
         return failed_output(diagnostics);
     }
-
     let rebuilt = SemanticBuilder::new()
         .with_check_syntax_error(true)
         .with_enum_eval(true)
@@ -550,7 +555,6 @@ pub fn emit_program(
     if rebuilt_has_errors {
         return failed_output(diagnostics);
     }
-
     let generated = Codegen::new()
         .with_options(CodegenOptions {
             source_map_path: options.sourcemap.then(|| PathBuf::from(filename)),
@@ -560,7 +564,6 @@ pub fn emit_program(
         .with_source_type(input_source_type)
         .with_scoping(Some(rebuilt.semantic.into_scoping()))
         .build(&program);
-
     let validation_type = output_source_type(options.module_kind);
     let validation = Parser::new(&allocator, &generated.code, validation_type)
         .with_options(ParseOptions {
@@ -586,7 +589,6 @@ pub fn emit_program(
     if validation_has_errors {
         return failed_output(diagnostics);
     }
-
     OxcCompileOutput {
         code: generated.code,
         source_map_json: generated.map.map(|map| map.to_json_string()),
@@ -594,7 +596,6 @@ pub fn emit_program(
         diagnostics: sorted(diagnostics),
     }
 }
-
 fn strip_compiler_macro_imports(program: &mut oxc::ast::ast::Program<'_>) {
     program.body.retain_mut(|statement| {
         let Statement::ImportDeclaration(declaration) = statement else {
@@ -619,7 +620,6 @@ fn strip_compiler_macro_imports(program: &mut oxc::ast::ast::Program<'_>) {
         original_len == specifiers.len() || !specifiers.is_empty()
     });
 }
-
 fn unsupported_operations(emit: &EmitProgram) -> Vec<Diagnostic> {
     let unsupported_scoped_helper = emit.functions.iter().find(|function| {
         function.context.is_none()
@@ -665,21 +665,19 @@ fn unsupported_operations(emit: &EmitProgram) -> Vec<Diagnostic> {
         vec![diagnostic]
     })
 }
-
 fn is_scoped_helper(helper: RuntimeHelper) -> bool {
     matches!(
         helper,
         RuntimeHelper::UseSignal | RuntimeHelper::UseMemo | RuntimeHelper::UseEffect
     )
 }
-
 #[derive(Debug, Clone)]
 struct CreationRewrite {
     local: Option<String>,
     context: Option<String>,
+    signal_name: Option<String>,
     derived: bool,
 }
-
 #[derive(Debug, Clone)]
 struct PropBindingRewrite {
     path: Vec<String>,
@@ -690,20 +688,17 @@ struct PropBindingRewrite {
     default_local: Option<String>,
     origin: SourceSpan,
 }
-
 #[derive(Debug, Clone)]
 struct PropCheckRewrite {
     path: Vec<String>,
     local: String,
     origin: SourceSpan,
 }
-
 #[derive(Debug, Clone)]
 struct PropsParameterDefaultRewrite {
     input: String,
     value: SourceSpan,
 }
-
 #[derive(Debug, Clone)]
 struct PropsRestRewrite {
     local: String,
@@ -711,7 +706,6 @@ struct PropsRestRewrite {
     helper: String,
     origin: SourceSpan,
 }
-
 #[derive(Debug, Clone)]
 struct PropsRewrite {
     source: String,
@@ -720,13 +714,11 @@ struct PropsRewrite {
     helper: Option<String>,
     bindings: Vec<PropBindingRewrite>,
 }
-
 struct PropsRewrites {
     parameters: BTreeMap<(u32, u32), PropsRewrite>,
     reads: BTreeSet<(u32, u32)>,
     diagnostics: Vec<Diagnostic>,
 }
-
 fn props_rewrites(emit: &EmitProgram) -> PropsRewrites {
     let helper_names: BTreeMap<_, _> = emit
         .imports
@@ -957,7 +949,6 @@ fn props_rewrites(emit: &EmitProgram) -> PropsRewrites {
         diagnostics,
     }
 }
-
 fn creation_rewrites(
     emit: &EmitProgram,
 ) -> (BTreeMap<(u32, u32), CreationRewrite>, Vec<Diagnostic>) {
@@ -1016,9 +1007,19 @@ fn creation_rewrites(
                 );
                 continue;
             }
+            let signal_name = match operation {
+                EmitOperation::CreateReactive { name, helper, .. }
+                    if matches!(helper, RuntimeHelper::Signal | RuntimeHelper::UseSignal) =>
+                {
+                    name
+                }
+                _ => &None,
+            }
+            .clone();
             let rewrite = CreationRewrite {
                 local: local.map(str::to_owned),
                 context,
+                signal_name,
                 derived: is_derived,
             };
             if rewrites
@@ -1038,7 +1039,6 @@ fn creation_rewrites(
     }
     (rewrites, diagnostics)
 }
-
 #[derive(Debug, Clone, Copy)]
 struct ReadRewrite {
     projected: bool,
@@ -1046,7 +1046,6 @@ struct ReadRewrite {
     projection_count: usize,
     optional_accessor: bool,
 }
-
 fn projection_is_optional(projection: &fict_hir::Projection) -> bool {
     match projection {
         fict_hir::Projection::StaticProperty { optional, .. }
@@ -1054,7 +1053,6 @@ fn projection_is_optional(projection: &fict_hir::Projection) -> bool {
         | fict_hir::Projection::Index { optional, .. } => *optional,
     }
 }
-
 fn read_rewrites(emit: &EmitProgram) -> (BTreeMap<(u32, u32), ReadRewrite>, Vec<Diagnostic>) {
     let mut reads = BTreeMap::new();
     let mut diagnostics = Vec::new();
@@ -1118,7 +1116,6 @@ fn read_rewrites(emit: &EmitProgram) -> (BTreeMap<(u32, u32), ReadRewrite>, Vec<
     }
     (reads, diagnostics)
 }
-
 #[derive(Debug, Clone)]
 enum MutationRewrite {
     Write,
@@ -1131,7 +1128,6 @@ enum MutationRewrite {
         targets: BTreeSet<(u32, u32)>,
     },
 }
-
 fn mutation_rewrites(
     emit: &EmitProgram,
 ) -> (BTreeMap<(u32, u32), MutationRewrite>, Vec<Diagnostic>) {
@@ -1215,12 +1211,10 @@ fn mutation_rewrites(
     }
     (mutations, diagnostics)
 }
-
 #[derive(Debug, Clone)]
 struct VNodeRewrite {
     fragment_local: Option<String>,
 }
-
 fn vnode_rewrites(emit: &EmitProgram) -> (BTreeMap<(u32, u32), VNodeRewrite>, Vec<Diagnostic>) {
     let helper_names: BTreeMap<_, _> = emit
         .imports
@@ -1283,7 +1277,6 @@ fn vnode_rewrites(emit: &EmitProgram) -> (BTreeMap<(u32, u32), VNodeRewrite>, Ve
     }
     (rewrites, diagnostics)
 }
-
 #[derive(Debug, Clone)]
 struct ComponentRewrite {
     props: Vec<ComponentProp>,
@@ -1295,7 +1288,6 @@ struct ComponentRewrite {
     reactive_function_helper: Option<String>,
     fragment_local: Option<String>,
 }
-
 fn component_rewrites(
     emit: &EmitProgram,
 ) -> (BTreeMap<(u32, u32), ComponentRewrite>, Vec<Diagnostic>) {
@@ -1464,20 +1456,17 @@ fn component_rewrites(
     }
     (rewrites, diagnostics)
 }
-
 #[derive(Debug)]
 struct TemplateSource {
     local: String,
     source: String,
 }
-
 #[derive(Debug, Clone)]
 struct CloneRewrite {
     factory: String,
     root: String,
     steps: Vec<FineJsxStep>,
 }
-
 #[derive(Debug, Clone)]
 enum FineJsxStep {
     Resolve {
@@ -1560,19 +1549,17 @@ enum FineJsxStep {
         needs_index: bool,
     },
 }
-
 #[derive(Debug, Clone)]
 enum FineJsxValue {
     Source(SourceSpan),
     Literal(LiteralValue),
 }
-
 struct TemplateRewrites {
     sources: Vec<TemplateSource>,
     clones: BTreeMap<(u32, u32), CloneRewrite>,
+    conditional_returns: BTreeMap<(u32, u32), conditional_return::ConditionalReturnRewrite>,
     diagnostics: Vec<Diagnostic>,
 }
-
 fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
     let helper_names: BTreeMap<_, _> = emit
         .imports
@@ -1637,8 +1624,8 @@ fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
             source: format!("const {local} = {call};"),
         });
     }
-
     let mut clones: BTreeMap<(u32, u32), CloneRewrite> = BTreeMap::new();
+    let mut conditional_returns = BTreeMap::new();
     for function in &emit.functions {
         let temporary_names: BTreeMap<_, _> = function
             .temporaries
@@ -1720,6 +1707,47 @@ fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
                         current = None;
                     } else {
                         current = Some(location);
+                    }
+                }
+                EmitOperation::ConditionalReturn {
+                    target,
+                    helper,
+                    create_helper,
+                    cleanup_helper,
+                    origin,
+                } => {
+                    let Some(span) = origin.primary_span else {
+                        diagnostics.push(emit_error(
+                            "FICT-OXC-EMIT-ORIGIN",
+                            "conditional return requires a source origin",
+                            GuaranteeClass::Internal,
+                        ));
+                        continue;
+                    };
+                    let plan = temporary_names
+                        .get(target)
+                        .copied()
+                        .zip(helper_names.get(helper).copied())
+                        .zip(helper_names.get(create_helper).copied())
+                        .zip(helper_names.get(cleanup_helper).copied())
+                        .map(|(((target, helper), create), cleanup)| {
+                            conditional_return::ConditionalReturnRewrite::new(
+                                target, helper, create, cleanup,
+                            )
+                        });
+                    if plan.is_none()
+                        || conditional_returns
+                            .insert((span.start(), span.end()), plan.expect("checked plan"))
+                            .is_some()
+                    {
+                        diagnostics.push(
+                            emit_error(
+                                "FICT-OXC-EMIT-CONDITIONAL-RETURN",
+                                "conditional return has missing or duplicate plan identity",
+                                GuaranteeClass::Internal,
+                            )
+                            .with_primary_span(span),
+                        );
                     }
                 }
                 EmitOperation::ResolveElement {
@@ -2611,10 +2639,10 @@ fn template_rewrites(emit: &EmitProgram) -> TemplateRewrites {
     TemplateRewrites {
         sources,
         clones,
+        conditional_returns,
         diagnostics,
     }
 }
-
 fn render_template_call(
     helper: &str,
     html: &str,
@@ -2639,10 +2667,8 @@ fn render_template_call(
     let html = quote_javascript_string(html);
     Some(format!("{helper}({html}{suffix})"))
 }
-
 fn quote_javascript_string(value: &str) -> String {
     use std::fmt::Write;
-
     let mut quoted = String::with_capacity(value.len() + 2);
     quoted.push('"');
     for character in value.chars() {
@@ -2666,7 +2692,6 @@ fn quote_javascript_string(value: &str) -> String {
     quoted.push('"');
     quoted
 }
-
 fn render_runtime_imports(emit: &EmitProgram) -> String {
     let mut output = String::new();
     for intent in &emit.imports {
@@ -2682,13 +2707,11 @@ fn render_runtime_imports(emit: &EmitProgram) -> String {
     }
     output
 }
-
 #[derive(Debug)]
 struct ContextSource {
     location: (u32, u32),
     source: String,
 }
-
 fn render_context_sources(emit: &EmitProgram) -> (Vec<ContextSource>, Vec<Diagnostic>) {
     let helper_names: BTreeMap<_, _> = emit
         .imports
@@ -2741,7 +2764,6 @@ fn render_context_sources(emit: &EmitProgram) -> (Vec<ContextSource>, Vec<Diagno
     }
     (sources, diagnostics)
 }
-
 fn parse_context_declarations<'a>(
     allocator: &'a Allocator,
     sources: &'a [ContextSource],
@@ -2769,7 +2791,6 @@ fn parse_context_declarations<'a>(
     }
     Ok(declarations)
 }
-
 fn parse_template_declarations<'a>(
     allocator: &'a Allocator,
     sources: &'a [TemplateSource],
@@ -2796,7 +2817,6 @@ fn parse_template_declarations<'a>(
     }
     Ok(declarations)
 }
-
 fn parse_generated_module_statements<'a>(
     allocator: &'a Allocator,
     source: &'a str,
@@ -2815,7 +2835,6 @@ fn parse_generated_module_statements<'a>(
     ZeroSpans.visit_program(&mut program);
     Ok(program.body.into_iter().collect())
 }
-
 fn preview_helper_local(
     emit: &EmitProgram,
     helper: RuntimeHelper,
@@ -2832,13 +2851,11 @@ fn preview_helper_local(
             ))
         })
 }
-
 fn render_preview_module_statements(
     emit: &EmitProgram,
     preview: &EmitPreviewPlan,
 ) -> Result<String, Box<Diagnostic>> {
     use std::fmt::Write;
-
     let mut source = String::new();
     let mut dependencies = BTreeSet::new();
     for handler in &preview.handlers {
@@ -2850,7 +2867,6 @@ fn render_preview_module_statements(
         writeln!(source, "export {{ {local} as {exported} }};")
             .expect("writing generated Preview source cannot fail");
     }
-
     if preview.components.is_empty() {
         return Ok(source);
     }
@@ -2882,7 +2898,6 @@ fn render_preview_module_statements(
     }
     Ok(source)
 }
-
 struct AstRewriter<'a, 'emit> {
     allocator: &'a Allocator,
     creations: &'emit BTreeMap<(u32, u32), CreationRewrite>,
@@ -2892,6 +2907,7 @@ struct AstRewriter<'a, 'emit> {
     mutations: &'emit BTreeMap<(u32, u32), MutationRewrite>,
     vnodes: &'emit BTreeMap<(u32, u32), VNodeRewrite>,
     components: &'emit BTreeMap<(u32, u32), ComponentRewrite>,
+    conditional_returns: &'emit BTreeMap<(u32, u32), conditional_return::ConditionalReturnRewrite>,
     clones: &'emit BTreeMap<(u32, u32), CloneRewrite>,
     preview_handlers: &'emit BTreeMap<(u32, u32), EmitPreviewHandler>,
     preview_qrl_local: Option<&'emit str>,
@@ -2904,6 +2920,7 @@ struct AstRewriter<'a, 'emit> {
     matched_mutations: BTreeSet<(u32, u32)>,
     matched_vnodes: BTreeSet<(u32, u32)>,
     matched_components: BTreeSet<(u32, u32)>,
+    matched_conditional_returns: BTreeSet<(u32, u32)>,
     matched_clones: BTreeSet<(u32, u32)>,
     vnode_shadowed_clones: BTreeSet<(u32, u32)>,
     active_list_reads: BTreeSet<(u32, u32)>,
@@ -2918,12 +2935,10 @@ struct AstRewriter<'a, 'emit> {
     await_allowed: bool,
     diagnostics: Vec<Diagnostic>,
 }
-
 enum VNodeChild<'a> {
     Value(Expression<'a>),
     Spread(Span, Expression<'a>),
 }
-
 fn jsx_attribute_name(name: JSXAttributeName<'_>) -> (String, Span) {
     match name {
         JSXAttributeName::Identifier(identifier) => (identifier.name.to_string(), identifier.span),
@@ -2933,7 +2948,6 @@ fn jsx_attribute_name(name: JSXAttributeName<'_>) -> (String, Span) {
         ),
     }
 }
-
 fn jsx_attribute_node_span(value: &Option<JSXAttributeValue<'_>>) -> Option<Span> {
     match value {
         Some(JSXAttributeValue::Element(element)) => Some(element.span),
@@ -2949,7 +2963,6 @@ fn jsx_attribute_node_span(value: &Option<JSXAttributeValue<'_>>) -> Option<Span
         Some(JSXAttributeValue::StringLiteral(_)) | None => None,
     }
 }
-
 fn jsx_attribute_source_span(value: &Option<JSXAttributeValue<'_>>) -> Option<Span> {
     match value {
         Some(JSXAttributeValue::StringLiteral(literal)) => Some(literal.span),
@@ -2961,7 +2974,6 @@ fn jsx_attribute_source_span(value: &Option<JSXAttributeValue<'_>>) -> Option<Sp
         None => None,
     }
 }
-
 fn clone_direct_jsx_key_expression<'a>(
     allocator: &'a Allocator,
     body: &Expression<'a>,
@@ -3005,13 +3017,11 @@ fn clone_direct_jsx_key_expression<'a>(
     }
     None
 }
-
 struct SourceExpressionCloner<'a> {
     allocator: &'a Allocator,
     target: (u32, u32),
     found: Option<Expression<'a>>,
 }
-
 impl<'a> Visit<'a> for SourceExpressionCloner<'a> {
     fn visit_expression(&mut self, expression: &Expression<'a>) {
         if self.found.is_some() {
@@ -3024,7 +3034,6 @@ impl<'a> Visit<'a> for SourceExpressionCloner<'a> {
         }
         walk::walk_expression(self, expression);
     }
-
     fn visit_function(&mut self, function: &Function<'a>, flags: ScopeFlags) {
         if self.found.is_some() {
             return;
@@ -3043,7 +3052,6 @@ impl<'a> Visit<'a> for SourceExpressionCloner<'a> {
         walk::walk_function(self, function, flags);
     }
 }
-
 fn clone_source_function_expression<'a>(
     allocator: &'a Allocator,
     program: &Program<'a>,
@@ -3056,7 +3064,6 @@ fn clone_source_function_expression<'a>(
         )
     })
 }
-
 fn clone_source_expression<'a>(
     allocator: &'a Allocator,
     program: &Program<'a>,
@@ -3070,7 +3077,6 @@ fn clone_source_expression<'a>(
     cloner.visit_program(program);
     cloner.found
 }
-
 fn clone_callback_expression<'a>(
     allocator: &'a Allocator,
     callback: &ArrowFunctionExpression<'a>,
@@ -3084,7 +3090,6 @@ fn clone_callback_expression<'a>(
     cloner.visit_arrow_function_expression(callback);
     cloner.found
 }
-
 fn keyed_list_namespace(namespace: DomNamespace) -> Option<&'static str> {
     match namespace {
         DomNamespace::Html => Some("html"),
@@ -3095,13 +3100,11 @@ fn keyed_list_namespace(namespace: DomNamespace) -> Option<&'static str> {
         DomNamespace::Parent => Some("parent"),
     }
 }
-
 fn component_node_origin_matches(origin: fict_hir::Origin, span: Span) -> bool {
     origin
         .primary_span
         .is_some_and(|source| source.start() == span.start && source.end() == span.end)
 }
-
 fn component_children_match(children: &[JSXChild<'_>], planned: &[ComponentChild]) -> bool {
     let mut planned = planned.iter();
     for child in children {
@@ -3160,7 +3163,6 @@ fn component_children_match(children: &[JSXChild<'_>], planned: &[ComponentChild
     }
     planned.next().is_none()
 }
-
 fn collect_object_pattern_defaults<'a>(
     pattern: &oxc::ast::ast::ObjectPattern<'a>,
     allocator: &'a Allocator,
@@ -3179,7 +3181,6 @@ fn collect_object_pattern_defaults<'a>(
         }
     }
 }
-
 impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
     fn visit_function(&mut self, function: &mut Function<'a>, flags: ScopeFlags) {
         let location = (function.span.start, function.span.end);
@@ -3188,13 +3189,19 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
             if let Some(declaration) = self.context_declarations.remove(&location) {
                 body.statements.insert(0, declaration);
             }
+            conditional_return::lower_statements(
+                self.allocator,
+                &mut body.statements,
+                self.conditional_returns,
+                &mut self.matched_conditional_returns,
+                function.r#async,
+            );
         }
         let previous_await_allowed = self.await_allowed;
         self.await_allowed = function.r#async;
         walk_mut::walk_function(self, function, flags);
         self.await_allowed = previous_await_allowed;
     }
-
     fn visit_arrow_function_expression(&mut self, function: &mut ArrowFunctionExpression<'a>) {
         let location = (function.span.start, function.span.end);
         if self.has_props_plan(&function.params) && function.expression {
@@ -3225,12 +3232,18 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
         if let Some(declaration) = self.context_declarations.remove(&location) {
             function.body.statements.insert(0, declaration);
         }
+        conditional_return::lower_statements(
+            self.allocator,
+            &mut function.body.statements,
+            self.conditional_returns,
+            &mut self.matched_conditional_returns,
+            function.r#async,
+        );
         let previous_await_allowed = self.await_allowed;
         self.await_allowed = function.r#async;
         walk_mut::walk_arrow_function_expression(self, function);
         self.await_allowed = previous_await_allowed;
     }
-
     fn visit_expression(&mut self, expression: &mut Expression<'a>) {
         let location = (expression.span().start, expression.span().end);
         if let Some(rewrite) = self
@@ -3373,13 +3386,21 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
             self.matched_reads.insert(location);
         }
     }
-
     fn visit_call_expression(&mut self, call: &mut oxc::ast::ast::CallExpression<'a>) {
         let location = (call.span.start, call.span.end);
-        if let Some((local, context)) = self.creations.get(&location).and_then(|rewrite| {
-            (!rewrite.derived).then_some((rewrite.local.as_deref()?, &rewrite.context))
-        }) && rename_callee(&mut call.callee, self.allocator.alloc_str(local))
+        if let Some((local, context, signal_name)) =
+            self.creations.get(&location).and_then(|rewrite| {
+                (!rewrite.derived).then_some((
+                    rewrite.local.as_deref()?,
+                    &rewrite.context,
+                    rewrite.signal_name.as_deref(),
+                ))
+            })
+            && rename_callee(&mut call.callee, self.allocator.alloc_str(local))
         {
+            if let Some(name) = signal_name {
+                self.append_signal_name(call, name);
+            }
             if let Some(context) = context {
                 let builder = AstBuilder::new(self.allocator);
                 let context = Expression::new_identifier(
@@ -3403,7 +3424,6 @@ impl<'a> VisitMut<'a> for AstRewriter<'a, '_> {
         walk_mut::walk_call_expression(self, call);
     }
 }
-
 impl<'a> AstRewriter<'a, '_> {
     fn has_props_plan(&self, parameters: &FormalParameters<'_>) -> bool {
         parameters.items.first().is_some_and(|parameter| {
@@ -3411,7 +3431,6 @@ impl<'a> AstRewriter<'a, '_> {
                 .contains_key(&(parameter.span.start, parameter.span.end))
         })
     }
-
     fn apply_props_plan(
         &mut self,
         parameters: &mut oxc::allocator::Box<'a, FormalParameters<'a>>,
@@ -3674,7 +3693,6 @@ impl<'a> AstRewriter<'a, '_> {
         }
         self.matched_props.insert(location);
     }
-
     fn prop_member(&self, source: &str, path: &[String], span: Span) -> Expression<'a> {
         let builder = AstBuilder::new(self.allocator);
         let mut value =
@@ -3700,7 +3718,6 @@ impl<'a> AstRewriter<'a, '_> {
         }
         value
     }
-
     fn prop_is_undefined(&self, source: &str, path: &[String], span: Span) -> Expression<'a> {
         Expression::new_binary_expression(
             span,
@@ -3710,7 +3727,6 @@ impl<'a> AstRewriter<'a, '_> {
             &AstBuilder::new(self.allocator),
         )
     }
-
     fn nested_prop_check_statement(&self, check: &PropCheckRewrite, span: Span) -> Statement<'a> {
         let builder = AstBuilder::new(self.allocator);
         let local =
@@ -3746,7 +3762,6 @@ impl<'a> AstRewriter<'a, '_> {
             &builder,
         )
     }
-
     fn props_rest_statement(
         &self,
         source: &str,
@@ -3779,7 +3794,6 @@ impl<'a> AstRewriter<'a, '_> {
         );
         const_statement(self.allocator, &rest.local, initializer, span)
     }
-
     fn identifier_is_undefined(&self, name: &str, span: Span) -> Expression<'a> {
         Expression::new_binary_expression(
             span,
@@ -3793,7 +3807,6 @@ impl<'a> AstRewriter<'a, '_> {
             &AstBuilder::new(self.allocator),
         )
     }
-
     fn void_zero(&self, span: Span) -> Expression<'a> {
         let builder = AstBuilder::new(self.allocator);
         Expression::new_unary_expression(
@@ -3803,7 +3816,6 @@ impl<'a> AstRewriter<'a, '_> {
             &builder,
         )
     }
-
     fn prepare_preview_qrl(
         &mut self,
         location: (u32, u32),
@@ -3862,7 +3874,6 @@ impl<'a> AstRewriter<'a, '_> {
             &builder,
         ))
     }
-
     fn lower_template_clone(
         &mut self,
         clone: CloneRewrite,
@@ -3883,7 +3894,6 @@ impl<'a> AstRewriter<'a, '_> {
         if clone.steps.is_empty() {
             return clone_call;
         }
-
         let mut values = jsx_dynamic_values(jsx, self.components);
         let mut statements = ArenaVec::new_in(&self.allocator);
         statements.push(const_statement(
@@ -4397,6 +4407,15 @@ impl<'a> AstRewriter<'a, '_> {
                                 continue;
                             }
                         };
+                    let branch_has_reads = |branch: &Expression<'a>| {
+                        let branch = branch.span();
+                        self.reads
+                            .keys()
+                            .chain(self.prop_reads.iter())
+                            .any(|&(start, end)| branch.start <= start && end <= branch.end)
+                    };
+                    let track_branch_reads = branch_has_reads(&consequent)
+                        || alternate.as_ref().is_some_and(branch_has_reads);
                     self.visit_expression(&mut test);
                     let consequent =
                         self.lower_conditional_branch(consequent, fragment_local.as_deref());
@@ -4454,11 +4473,21 @@ impl<'a> AstRewriter<'a, '_> {
                             &builder,
                         )),
                     ]);
+                    if track_branch_reads {
+                        let mut properties = ArenaVec::new_in(&self.allocator);
+                        properties.push(self.object_property(
+                            span,
+                            "trackBranchReads",
+                            Expression::new_boolean_literal(span, true, &builder),
+                        ));
+                        arguments.push(Argument::from(Expression::new_object_expression(
+                            span, properties, &builder,
+                        )));
+                    }
                     let call = Expression::new_call_expression(
                         span, callee, NONE, arguments, false, &builder,
                     );
                     statements.push(const_statement(self.allocator, &target, call, span));
-
                     let target_expression = Expression::new_identifier(
                         span,
                         self.allocator.alloc_str(&target),
@@ -4552,7 +4581,6 @@ impl<'a> AstRewriter<'a, '_> {
         statements.push(Statement::new_return_statement(span, Some(root), &builder));
         block_iife(self.allocator, statements, span, self.await_allowed)
     }
-
     fn lower_conditional_branch(
         &mut self,
         mut branch: Expression<'a>,
@@ -4568,7 +4596,6 @@ impl<'a> AstRewriter<'a, '_> {
         self.active_fragment_local = previous_fragment;
         branch
     }
-
     #[allow(clippy::too_many_arguments)]
     fn lower_keyed_list_step(
         &mut self,
@@ -4770,7 +4797,6 @@ impl<'a> AstRewriter<'a, '_> {
                 &builder,
             );
         }
-
         let mut key_callback = render_callback.clone_in(self.allocator);
         if let Some((_, key_source_origin)) = explicit_key {
             let Some(mut key_expression) =
@@ -4823,7 +4849,6 @@ impl<'a> AstRewriter<'a, '_> {
         if explicit_key.is_some() {
             append_arrow_parameter(self.allocator, &mut render_callback, render_key, span);
         }
-
         let expected_reads: BTreeSet<_> = item_references
             .iter()
             .chain(index_references)
@@ -4877,7 +4902,6 @@ impl<'a> AstRewriter<'a, '_> {
             );
             return;
         }
-
         let builder = AstBuilder::new(self.allocator);
         let get_items = zero_parameter_expression_arrow(self.allocator, items, span);
         let callee = Expression::new_identifier(span, self.allocator.alloc_str(helper), &builder);
@@ -4906,7 +4930,6 @@ impl<'a> AstRewriter<'a, '_> {
         }
         let call = Expression::new_call_expression(span, callee, NONE, arguments, false, &builder);
         statements.push(const_statement(self.allocator, target, call, span));
-
         let target_expression =
             Expression::new_identifier(span, self.allocator.alloc_str(target), &builder);
         let flush = Expression::new_static_member_expression(
@@ -4937,7 +4960,6 @@ impl<'a> AstRewriter<'a, '_> {
             flush_chain,
             &builder,
         ));
-
         let target_expression =
             Expression::new_identifier(span, self.allocator.alloc_str(target), &builder);
         let dispose = Expression::new_static_member_expression(
@@ -4965,7 +4987,6 @@ impl<'a> AstRewriter<'a, '_> {
             &builder,
         ));
     }
-
     fn lower_planned_jsx_element(&mut self, element: JSXElement<'a>) -> Expression<'a> {
         let location = (element.span.start, element.span.end);
         let Some(component) = self.components.get(&location).cloned() else {
@@ -4978,7 +4999,6 @@ impl<'a> AstRewriter<'a, '_> {
         self.matched_components.insert(location);
         lowered
     }
-
     fn lower_component_element(
         &mut self,
         element: JSXElement<'a>,
@@ -5222,7 +5242,6 @@ impl<'a> AstRewriter<'a, '_> {
             }
             properties.push(self.object_property(span, "children", children));
         }
-
         let builder = AstBuilder::new(self.allocator);
         if !properties.is_empty() {
             prop_segments.push(Expression::new_object_expression(
@@ -5258,7 +5277,6 @@ impl<'a> AstRewriter<'a, '_> {
         }
         Expression::new_object_expression(span, vnode, &builder)
     }
-
     fn lower_jsx_expression(&mut self, expression: Expression<'a>) -> Expression<'a> {
         match expression {
             Expression::JSXElement(element) => self.lower_planned_jsx_element(element.unbox()),
@@ -5266,14 +5284,12 @@ impl<'a> AstRewriter<'a, '_> {
             _ => unreachable!("VNode lowering only accepts JSX expressions"),
         }
     }
-
     fn lower_jsx_element(&mut self, element: JSXElement<'a>) -> Expression<'a> {
         let span = element.span;
         let opening = element.opening_element.unbox();
         let element_type = self.lower_jsx_element_name(opening.name);
         let mut properties = ArenaVec::new_in(&self.allocator);
         let mut key = None;
-
         for attribute in opening.attributes {
             match attribute {
                 JSXAttributeItem::SpreadAttribute(spread) => {
@@ -5321,11 +5337,9 @@ impl<'a> AstRewriter<'a, '_> {
                 }
             }
         }
-
         if let Some(children) = self.lower_jsx_children(element.children, span, None) {
             properties.push(self.object_property(span, "children", children));
         }
-
         let builder = AstBuilder::new(self.allocator);
         let props = if properties.is_empty() {
             Expression::new_null_literal(span, &builder)
@@ -5340,7 +5354,6 @@ impl<'a> AstRewriter<'a, '_> {
         }
         Expression::new_object_expression(span, vnode, &builder)
     }
-
     fn lower_jsx_fragment(&mut self, fragment: JSXFragment<'a>) -> Expression<'a> {
         let span = fragment.span;
         let builder = AstBuilder::new(self.allocator);
@@ -5370,7 +5383,6 @@ impl<'a> AstRewriter<'a, '_> {
         vnode.push(self.object_property(span, "props", props));
         Expression::new_object_expression(span, vnode, &builder)
     }
-
     fn lower_jsx_element_name(&mut self, name: JSXElementName<'a>) -> Expression<'a> {
         let builder = AstBuilder::new(self.allocator);
         match name {
@@ -5397,7 +5409,6 @@ impl<'a> AstRewriter<'a, '_> {
             JSXElementName::ThisExpression(expression) => Expression::ThisExpression(expression),
         }
     }
-
     fn lower_jsx_member_expression(&mut self, member: JSXMemberExpression<'a>) -> Expression<'a> {
         let object = match member.object {
             JSXMemberExpressionObject::IdentifierReference(identifier) => {
@@ -5425,7 +5436,6 @@ impl<'a> AstRewriter<'a, '_> {
             &AstBuilder::new(self.allocator),
         )
     }
-
     fn lower_jsx_attribute_value(
         &mut self,
         value: Option<JSXAttributeValue<'a>>,
@@ -5461,7 +5471,6 @@ impl<'a> AstRewriter<'a, '_> {
             }
         }
     }
-
     fn lower_jsx_children(
         &mut self,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -5555,7 +5564,6 @@ impl<'a> AstRewriter<'a, '_> {
             }
         }
     }
-
     fn wrap_non_reactive_component_child(
         &mut self,
         value: Expression<'a>,
@@ -5586,7 +5594,6 @@ impl<'a> AstRewriter<'a, '_> {
         arguments.push(Argument::from(value));
         Expression::new_call_expression(span, callee, NONE, arguments, false, &builder)
     }
-
     fn lower_jsx_container_expression(&mut self, mut expression: Expression<'a>) -> Expression<'a> {
         if matches!(
             expression.get_inner_expression(),
@@ -5600,7 +5607,6 @@ impl<'a> AstRewriter<'a, '_> {
             expression
         }
     }
-
     fn object_property(
         &self,
         span: Span,
@@ -5625,7 +5631,44 @@ impl<'a> AstRewriter<'a, '_> {
             &builder,
         )
     }
-
+    fn append_signal_name(&self, call: &mut CallExpression<'a>, name: &str) {
+        let span = call.span;
+        let builder = AstBuilder::new(self.allocator);
+        let name_property = || {
+            self.object_property(
+                span,
+                "name",
+                Expression::new_string_literal(
+                    span,
+                    self.allocator.alloc_str(name),
+                    None,
+                    &builder,
+                ),
+            )
+        };
+        if let Some(Argument::ObjectExpression(options)) = call.arguments.get_mut(1) {
+            if !options.properties.iter().any(|property| {
+                matches!(property, ObjectPropertyKind::ObjectProperty(property) if property.key.static_name().is_some_and(|key| key == "name"))
+            }) {
+                options.properties.push(name_property());
+            }
+            return;
+        }
+        let mut properties = ArenaVec::new_in(&self.allocator);
+        if call.arguments.len() > 1 {
+            let source = match call.arguments.remove(1) {
+                Argument::SpreadElement(spread) => spread.unbox().argument,
+                argument => argument.into_expression(),
+            };
+            properties.push(ObjectPropertyKind::new_spread_property(
+                span, source, &builder,
+            ));
+        }
+        properties.push(name_property());
+        let options = Expression::new_object_expression(span, properties, &builder);
+        let index = call.arguments.len().min(1);
+        call.arguments.insert(index, Argument::from(options));
+    }
     fn rewrite_mutation(
         &mut self,
         expression: &mut Expression<'a>,
@@ -5754,7 +5797,6 @@ impl<'a> AstRewriter<'a, '_> {
         }
     }
 }
-
 fn rewrite_pattern_assignment_target<'a>(
     target: &mut AssignmentTarget<'a>,
     expected: &BTreeSet<(u32, u32)>,
@@ -5796,7 +5838,6 @@ fn rewrite_pattern_assignment_target<'a>(
         | AssignmentTarget::PrivateFieldExpression(_) => {}
     }
 }
-
 fn rewrite_pattern_maybe_default<'a>(
     target: &mut AssignmentTargetMaybeDefault<'a>,
     expected: &BTreeSet<(u32, u32)>,
@@ -5814,7 +5855,6 @@ fn rewrite_pattern_maybe_default<'a>(
     rewrite_pattern_assignment_target(&mut assignment_target, expected, matched, allocator);
     *target = assignment_target.into();
 }
-
 fn rewrite_pattern_property<'a>(
     property: &mut AssignmentTargetProperty<'a>,
     expected: &BTreeSet<(u32, u32)>,
@@ -5862,7 +5902,6 @@ fn rewrite_pattern_property<'a>(
         }
     }
 }
-
 fn direct_pattern_target_identifier(target: &AssignmentTarget<'_>) -> Option<(String, Span)> {
     let identifier = match target {
         AssignmentTarget::AssignmentTargetIdentifier(identifier) => Some(identifier.as_ref()),
@@ -5886,7 +5925,6 @@ fn direct_pattern_target_identifier(target: &AssignmentTarget<'_>) -> Option<(St
     }?;
     Some((identifier.name.to_string(), identifier.span))
 }
-
 fn direct_pattern_expression_identifier<'a, 'expression>(
     expression: &'expression Expression<'a>,
 ) -> Option<&'expression IdentifierReference<'a>> {
@@ -5895,7 +5933,6 @@ fn direct_pattern_expression_identifier<'a, 'expression>(
         _ => None,
     }
 }
-
 fn reactive_setter_assignment_target<'a>(
     allocator: &'a Allocator,
     signal: &str,
@@ -5905,7 +5942,6 @@ fn reactive_setter_assignment_target<'a>(
     let setter_property = "__fictSetter";
     let value_property = "__fictValue";
     let parameter_name = "__fictNext";
-
     let mut properties = ArenaVec::new_in(&allocator);
     properties.push(ObjectPropertyKind::new_object_property(
         span,
@@ -5917,7 +5953,6 @@ fn reactive_setter_assignment_target<'a>(
         false,
         &builder,
     ));
-
     let parameter_pattern = BindingPattern::new_binding_identifier(span, parameter_name, &builder);
     let parameter = FormalParameter::new(
         span,
@@ -6001,7 +6036,6 @@ fn reactive_setter_assignment_target<'a>(
         &builder,
     )
 }
-
 fn jsx_dynamic_values<'a>(
     jsx: Expression<'a>,
     components: &BTreeMap<(u32, u32), ComponentRewrite>,
@@ -6018,7 +6052,6 @@ fn jsx_dynamic_values<'a>(
     }
     values
 }
-
 fn collect_jsx_element_values<'a>(
     element: JSXElement<'a>,
     values: &mut BTreeMap<(u32, u32), Expression<'a>>,
@@ -6067,7 +6100,6 @@ fn collect_jsx_element_values<'a>(
     }
     collect_jsx_children_values(element.children, values, components);
 }
-
 fn collect_jsx_children_values<'a>(
     children: ArenaVec<'a, JSXChild<'a>>,
     values: &mut BTreeMap<(u32, u32), Expression<'a>>,
@@ -6101,7 +6133,6 @@ fn collect_jsx_children_values<'a>(
         }
     }
 }
-
 fn collect_jsx_expression_value<'a>(
     expression: Expression<'a>,
     values: &mut BTreeMap<(u32, u32), Expression<'a>>,
@@ -6130,7 +6161,6 @@ fn collect_jsx_expression_value<'a>(
         values.insert((span.start, span.end), expression);
     }
 }
-
 fn const_statement<'a>(
     allocator: &'a Allocator,
     name: &str,
@@ -6145,7 +6175,6 @@ fn const_statement<'a>(
         VariableDeclarationKind::Const,
     )
 }
-
 fn variable_statement<'a>(
     allocator: &'a Allocator,
     name: &str,
@@ -6168,7 +6197,6 @@ fn variable_statement<'a>(
     declarations.push(declarator);
     Statement::new_variable_declaration(span, kind, declarations, false, &builder)
 }
-
 fn dom_literal_expression<'a>(
     allocator: &'a Allocator,
     value: &LiteralValue,
@@ -6196,12 +6224,10 @@ fn dom_literal_expression<'a>(
         | LiteralValue::RegExp { .. } => None,
     }
 }
-
 fn encode_javascript_string_for_oxc(value: &JavaScriptString) -> (String, bool) {
     if let Some(value) = value.to_utf8() {
         return (value, false);
     }
-
     let mut encoded = String::new();
     for character in char::decode_utf16(value.as_code_units().iter().copied()) {
         match character {
@@ -6212,7 +6238,6 @@ fn encode_javascript_string_for_oxc(value: &JavaScriptString) -> (String, bool) 
     }
     (encoded, true)
 }
-
 fn push_oxc_utf16_marker(output: &mut String, code_unit: u16) {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     output.push('\u{fffd}');
@@ -6220,7 +6245,6 @@ fn push_oxc_utf16_marker(output: &mut String, code_unit: u16) {
         output.push(char::from(HEX[usize::from((code_unit >> shift) & 0x0f)]));
     }
 }
-
 fn zero_parameter_expression_arrow<'a>(
     allocator: &'a Allocator,
     expression: Expression<'a>,
@@ -6243,7 +6267,6 @@ fn zero_parameter_expression_arrow<'a>(
         span, true, false, NONE, parameters, NONE, body, &builder,
     )
 }
-
 fn derived_accessor_expression<'a>(
     allocator: &'a Allocator,
     initializer: Expression<'a>,
@@ -6265,7 +6288,6 @@ fn derived_accessor_expression<'a>(
     );
     Expression::new_call_expression(span, callee, NONE, arguments, false, &builder)
 }
-
 fn ignore_inline_event_handler_return<'a>(
     allocator: &'a Allocator,
     handler: Expression<'a>,
@@ -6275,7 +6297,6 @@ fn ignore_inline_event_handler_return<'a>(
     if !arrow && !matches!(handler, Expression::FunctionExpression(_)) {
         return handler;
     }
-
     let mut collector = IdentifierCollector::default();
     collector.visit_expression(&handler);
     let mut parameter = "__fictArgs".to_owned();
@@ -6345,7 +6366,6 @@ fn ignore_inline_event_handler_return<'a>(
         )
     }
 }
-
 fn handler_may_prevent_default(handler: &Expression<'_>) -> bool {
     let handler = handler.get_inner_expression();
     let (parameters, body) = match handler {
@@ -6371,13 +6391,11 @@ fn handler_may_prevent_default(handler: &Expression<'_>) -> bool {
     }
     finder.found
 }
-
 struct PreventDefaultFinder<'name> {
     event_parameter: &'name str,
     shadow_depth: usize,
     found: bool,
 }
-
 impl<'a> Visit<'a> for PreventDefaultFinder<'_> {
     fn visit_function(&mut self, function: &Function<'a>, flags: ScopeFlags) {
         if self.found {
@@ -6388,7 +6406,6 @@ impl<'a> Visit<'a> for PreventDefaultFinder<'_> {
         walk::walk_function(self, function, flags);
         self.shadow_depth -= usize::from(shadows_event);
     }
-
     fn visit_arrow_function_expression(&mut self, function: &ArrowFunctionExpression<'a>) {
         if self.found {
             return;
@@ -6398,7 +6415,6 @@ impl<'a> Visit<'a> for PreventDefaultFinder<'_> {
         walk::walk_arrow_function_expression(self, function);
         self.shadow_depth -= usize::from(shadows_event);
     }
-
     fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
         if self.found {
             return;
@@ -6422,7 +6438,6 @@ impl<'a> Visit<'a> for PreventDefaultFinder<'_> {
         walk::walk_call_expression(self, call);
     }
 }
-
 fn formal_parameters_bind_name(parameters: &FormalParameters<'_>, name: &str) -> bool {
     parameters
         .items
@@ -6433,7 +6448,6 @@ fn formal_parameters_bind_name(parameters: &FormalParameters<'_>, name: &str) ->
             .as_ref()
             .is_some_and(|rest| binding_pattern_binds_name(&rest.rest.argument, name))
 }
-
 fn binding_pattern_binds_name(pattern: &BindingPattern<'_>, name: &str) -> bool {
     match pattern {
         BindingPattern::BindingIdentifier(identifier) => identifier.name == name,
@@ -6463,18 +6477,15 @@ fn binding_pattern_binds_name(pattern: &BindingPattern<'_>, name: &str) -> bool 
         }
     }
 }
-
 #[derive(Default)]
 struct IdentifierCollector {
     names: BTreeSet<String>,
 }
-
 impl<'a> Visit<'a> for IdentifierCollector {
     fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'a>) {
         self.names.insert(identifier.name.to_string());
     }
 }
-
 fn insertion_create_callback<'a>(
     allocator: &'a Allocator,
     helper: &str,
@@ -6486,7 +6497,6 @@ fn insertion_create_callback<'a>(
     if namespace == DomNamespace::Html {
         return Expression::new_identifier(span, allocator.alloc_str(helper), &builder);
     }
-
     let parameter = allocator.alloc_str("__fict_child");
     let callee = Expression::new_identifier(span, allocator.alloc_str(helper), &builder);
     let child = Expression::new_identifier(span, parameter, &builder);
@@ -6513,7 +6523,6 @@ fn insertion_create_callback<'a>(
     let body = Expression::new_call_expression(span, callee, NONE, arguments, false, &builder);
     expression_arrow(allocator, parameter, body, span)
 }
-
 fn block_iife<'a>(
     allocator: &'a Allocator,
     statements: ArenaVec<'a, Statement<'a>>,
@@ -6554,7 +6563,6 @@ fn block_iife<'a>(
         call
     }
 }
-
 fn statements_contain_direct_await(statements: &[Statement<'_>]) -> bool {
     let mut finder = DirectAwaitFinder { found: false };
     for statement in statements {
@@ -6565,35 +6573,28 @@ fn statements_contain_direct_await(statements: &[Statement<'_>]) -> bool {
     }
     false
 }
-
 struct DirectAwaitFinder {
     found: bool,
 }
-
 impl<'a> Visit<'a> for DirectAwaitFinder {
     fn visit_await_expression(&mut self, _expression: &AwaitExpression<'a>) {
         self.found = true;
     }
-
     fn visit_function(&mut self, _function: &Function<'a>, _flags: ScopeFlags) {}
-
     fn visit_arrow_function_expression(&mut self, _function: &ArrowFunctionExpression<'a>) {}
 }
-
 fn assignment_target_name(target: &AssignmentTarget<'_>) -> Option<String> {
     let AssignmentTarget::AssignmentTargetIdentifier(identifier) = target else {
         return None;
     };
     Some(identifier.name.to_string())
 }
-
 fn simple_assignment_target_name(target: &SimpleAssignmentTarget<'_>) -> Option<String> {
     let SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) = target else {
         return None;
     };
     Some(identifier.name.to_string())
 }
-
 fn compound_binary_operator(operator: CompoundAssignmentOperator) -> Option<OxcBinaryOperator> {
     Some(match operator {
         CompoundAssignmentOperator::Add => OxcBinaryOperator::Addition,
@@ -6613,7 +6614,6 @@ fn compound_binary_operator(operator: CompoundAssignmentOperator) -> Option<OxcB
         | CompoundAssignmentOperator::NullishCoalescing => return None,
     })
 }
-
 fn compound_logical_operator(operator: CompoundAssignmentOperator) -> Option<OxcLogicalOperator> {
     match operator {
         CompoundAssignmentOperator::LogicalAnd => Some(OxcLogicalOperator::And),
@@ -6622,14 +6622,12 @@ fn compound_logical_operator(operator: CompoundAssignmentOperator) -> Option<Oxc
         _ => None,
     }
 }
-
 fn update_binary_operator(operator: UpdateOperator) -> OxcBinaryOperator {
     match operator {
         UpdateOperator::Increment => OxcBinaryOperator::Addition,
         UpdateOperator::Decrement => OxcBinaryOperator::Subtraction,
     }
 }
-
 fn getter_call<'a>(allocator: &'a Allocator, signal: &str, span: Span) -> Expression<'a> {
     let builder = AstBuilder::new(allocator);
     let callee = Expression::new_identifier(span, allocator.alloc_str(signal), &builder);
@@ -6642,7 +6640,6 @@ fn getter_call<'a>(allocator: &'a Allocator, signal: &str, span: Span) -> Expres
         &builder,
     )
 }
-
 fn rewrite_reactive_accessor<'a>(
     expression: &mut Expression<'a>,
     accessor_depth: usize,
@@ -6666,7 +6663,6 @@ fn rewrite_reactive_accessor<'a>(
         allocator,
     )
 }
-
 fn rewrite_reactive_accessor_with_depth<'a>(
     expression: &mut Expression<'a>,
     accessor_depth: usize,
@@ -6794,7 +6790,6 @@ fn rewrite_reactive_accessor_with_depth<'a>(
         _ => false,
     }
 }
-
 fn expression_projection_depth(expression: &Expression<'_>) -> Option<usize> {
     match expression {
         Expression::Identifier(_) | Expression::CallExpression(_) => Some(0),
@@ -6843,7 +6838,6 @@ fn expression_projection_depth(expression: &Expression<'_>) -> Option<usize> {
         _ => None,
     }
 }
-
 fn projected_read_root_location(expression: &Expression<'_>) -> Option<(u32, u32)> {
     match expression {
         Expression::Identifier(identifier) => Some((identifier.span.start, identifier.span.end)),
@@ -6888,7 +6882,6 @@ fn projected_read_root_location(expression: &Expression<'_>) -> Option<(u32, u32
         _ => None,
     }
 }
-
 fn projected_chain_read_root_location(
     expression: &Expression<'_>,
     reads: &BTreeMap<(u32, u32), ReadRewrite>,
@@ -6946,7 +6939,6 @@ fn projected_chain_read_root_location(
         _ => None,
     }
 }
-
 fn rewrite_reactive_root<'a>(expression: &mut Expression<'a>, allocator: &'a Allocator) -> bool {
     match expression {
         Expression::Identifier(_) | Expression::CallExpression(_) => {
@@ -7007,7 +6999,6 @@ fn rewrite_reactive_root<'a>(expression: &mut Expression<'a>, allocator: &'a All
         _ => false,
     }
 }
-
 fn setter_call<'a>(
     allocator: &'a Allocator,
     signal: &str,
@@ -7020,7 +7011,6 @@ fn setter_call<'a>(
     arguments.push(Argument::from(value));
     Expression::new_call_expression(span, callee, NONE, arguments, false, &builder)
 }
-
 fn value_preserving_setter<'a>(
     allocator: &'a Allocator,
     signal: &str,
@@ -7042,7 +7032,6 @@ fn value_preserving_setter<'a>(
     arguments.push(Argument::from(value));
     Expression::new_call_expression(span, arrow, NONE, arguments, false, &builder)
 }
-
 fn logical_compound_update<'a>(
     allocator: &'a Allocator,
     signal: &str,
@@ -7061,7 +7050,6 @@ fn logical_compound_update<'a>(
     arguments.push(Argument::from(current));
     Expression::new_call_expression(span, arrow, NONE, arguments, false, &builder)
 }
-
 fn postfix_update<'a>(
     allocator: &'a Allocator,
     signal: &str,
@@ -7092,7 +7080,6 @@ fn postfix_update<'a>(
     arguments.push(Argument::from(current));
     Expression::new_call_expression(span, arrow, NONE, arguments, false, &builder)
 }
-
 fn expression_arrow<'a>(
     allocator: &'a Allocator,
     parameter: &'a str,
@@ -7131,7 +7118,6 @@ fn expression_arrow<'a>(
         span, true, false, NONE, parameters, NONE, body, &builder,
     )
 }
-
 fn direct_arrow_return_expression<'a, 'callback>(
     callback: &'callback ArrowFunctionExpression<'a>,
 ) -> Option<&'callback Expression<'a>> {
@@ -7146,7 +7132,6 @@ fn direct_arrow_return_expression<'a, 'callback>(
     };
     statement.argument.as_ref()
 }
-
 fn into_list_render_arrow<'a>(
     allocator: &'a Allocator,
     callback: Expression<'a>,
@@ -7181,7 +7166,6 @@ fn into_list_render_arrow<'a>(
         _ => None,
     }
 }
-
 fn replace_arrow_body_with_expression<'a>(
     allocator: &'a Allocator,
     arrow: &mut oxc::allocator::Box<'a, ArrowFunctionExpression<'a>>,
@@ -7196,7 +7180,6 @@ fn replace_arrow_body_with_expression<'a>(
     arrow.expression = true;
     arrow.body = FunctionBody::boxed(span, ArenaVec::new_in(&allocator), statements, &builder);
 }
-
 fn append_arrow_parameter<'a>(
     allocator: &'a Allocator,
     arrow: &mut oxc::allocator::Box<'a, ArrowFunctionExpression<'a>>,
@@ -7218,7 +7201,6 @@ fn append_arrow_parameter<'a>(
         &builder,
     ));
 }
-
 fn simple_arrow_parameter_name<'a>(
     arrow: &'a ArrowFunctionExpression<'_>,
     index: usize,
@@ -7232,7 +7214,6 @@ fn simple_arrow_parameter_name<'a>(
     };
     Some(identifier.name.as_str())
 }
-
 fn generated_parameter_name<'a>(
     allocator: &'a Allocator,
     signal: &str,
@@ -7247,7 +7228,6 @@ fn generated_parameter_name<'a>(
     }
     allocator.alloc_str(&candidate)
 }
-
 fn rename_callee<'a>(expression: &mut Expression<'a>, local: &'a str) -> bool {
     match expression {
         Expression::Identifier(identifier) => {
@@ -7276,15 +7256,12 @@ fn rename_callee<'a>(expression: &mut Expression<'a>, local: &'a str) -> bool {
         _ => false,
     }
 }
-
 pub(crate) struct ZeroSpans;
-
 impl<'a> VisitMut<'a> for ZeroSpans {
     fn visit_span(&mut self, span: &mut Span) {
         *span = Span::default();
     }
 }
-
 fn output_source_type(module_kind: OxcModuleKind) -> SourceType {
     match module_kind {
         OxcModuleKind::Module => SourceType::mjs(),
@@ -7293,7 +7270,6 @@ fn output_source_type(module_kind: OxcModuleKind) -> SourceType {
         OxcModuleKind::Unambiguous => SourceType::unambiguous(),
     }
 }
-
 fn operation_origin(operation: &EmitOperation) -> fict_hir::Origin {
     match operation {
         EmitOperation::PreserveHir { origin, .. }
@@ -7318,17 +7294,16 @@ fn operation_origin(operation: &EmitOperation) -> fict_hir::Origin {
         | EmitOperation::Evaluate { origin, .. }
         | EmitOperation::Insert { origin, .. }
         | EmitOperation::Conditional { origin, .. }
+        | EmitOperation::ConditionalReturn { origin, .. }
         | EmitOperation::KeyedChild { origin, .. }
         | EmitOperation::KeyedList { origin, .. }
         | EmitOperation::Return { origin, .. } => *origin,
     }
 }
-
 fn with_operation_span(mut diagnostic: Diagnostic, origin: fict_hir::Origin) -> Diagnostic {
     diagnostic.primary_span = origin.primary_span;
     diagnostic
 }
-
 fn emit_error(
     code: &'static str,
     message: impl Into<String>,
@@ -7341,9 +7316,10 @@ fn emit_error(
     )
     .with_guarantee_class(guarantee)
 }
-
 #[cfg(test)]
 mod tests {
+    use super::{emit_program, encode_javascript_string_for_oxc};
+    use crate::{OxcCompileOptions, OxcModuleKind, OxcSourceLanguage, OxcTypeScriptOptions};
     use fict_emit::{
         CleanupOwner, EmitContext, EmitFunction, EmitModulePlan, EmitOperation, EmitProgram,
         EmitSlotId, EmitValueRef, ReactiveSlot, ReactiveSlotKind, ReactiveSlotStorage,
@@ -7354,10 +7330,6 @@ mod tests {
         SourceSpan, UpdateOperator, ValueId,
     };
     use fict_reactivity::{StructurizeAnalysis, StructurizeStats};
-
-    use super::{emit_program, encode_javascript_string_for_oxc};
-    use crate::{OxcCompileOptions, OxcModuleKind, OxcSourceLanguage, OxcTypeScriptOptions};
-
     fn options(language: OxcSourceLanguage, sourcemap: bool) -> OxcCompileOptions {
         OxcCompileOptions {
             language,
@@ -7366,7 +7338,6 @@ mod tests {
             sourcemap,
         }
     }
-
     #[test]
     fn encodes_exact_utf16_strings_for_oxc_without_replacement_loss() {
         let well_formed = JavaScriptString::from("value � 😀");
@@ -7374,7 +7345,6 @@ mod tests {
             encode_javascript_string_for_oxc(&well_formed),
             ("value � 😀".to_owned(), false)
         );
-
         let exact = JavaScriptString::from_code_units(vec![
             u16::from(b'a'),
             0xd800,
@@ -7388,7 +7358,6 @@ mod tests {
             ("a\u{fffd}d800\u{fffd}fffd😀\u{fffd}dc00".to_owned(), true,)
         );
     }
-
     fn effect_program(source: &str) -> EmitProgram {
         let call = "$effect(() => 1)";
         let start = u32::try_from(source.find(call).expect("effect call")).expect("span");
@@ -7441,7 +7410,6 @@ mod tests {
             }],
         }
     }
-
     #[test]
     fn rewrites_calls_in_oxc_ast_injects_imports_and_emits_maps() {
         let source = "import { $effect } from 'fict';\nconst value: number = 1;\n$effect(() => 1);\nexport { value };";
@@ -7462,25 +7430,21 @@ mod tests {
         assert!(map.contains("effect.ts"));
         assert!(map.contains("mappings"));
     }
-
     #[test]
     fn erases_only_exact_compiler_macro_import_specifiers() {
         let source = "import { $effect, batch } from 'fict';\n$effect(() => 1);\nexport { batch };";
         let emit = effect_program(source);
-
         let output = emit_program(
             source,
             "mixed-import.js",
             options(OxcSourceLanguage::JavaScript, false),
             &emit,
         );
-
         assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
         assert!(!output.code.contains("$effect"));
         assert!(output.code.contains("import { batch } from \"fict\""));
         assert!(output.code.contains("export { batch }"));
     }
-
     #[test]
     fn fails_closed_for_unmaterialized_operations_and_bad_origins() {
         let source = "import { $effect } from 'fict'; $effect(() => 1);";
@@ -7511,7 +7475,6 @@ mod tests {
                 .iter()
                 .any(|diagnostic| diagnostic.code.as_str() == "FICT-OXC-EMIT-UNSUPPORTED")
         );
-
         let mut bad_origin = effect_program(source);
         let EmitOperation::RegisterEffect { origin, .. } =
             &mut bad_origin.functions[0].operations[0]
@@ -7533,7 +7496,6 @@ mod tests {
                 .any(|diagnostic| diagnostic.code.as_str() == "FICT-OXC-EMIT-ORIGIN")
         );
     }
-
     #[test]
     fn materializes_unprojected_reactive_reads_as_accessor_calls() {
         let source = "const memo = () => 1; export const value = memo + memo;";
@@ -7559,18 +7521,15 @@ mod tests {
                     ),
                 });
         }
-
         let output = emit_program(
             source,
             "read.js",
             options(OxcSourceLanguage::JavaScript, false),
             &emit,
         );
-
         assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
         assert!(output.code.contains("value = memo() + memo()"));
     }
-
     #[test]
     fn materializes_projected_reactive_reads_at_the_root_only() {
         let source = "const state = () => ({}); export const values = [state.user.name, state?.items?.[key()]];";

--- a/crates/fict-compiler-oxc/src/emit_codegen.rs
+++ b/crates/fict-compiler-oxc/src/emit_codegen.rs
@@ -1008,11 +1008,11 @@ fn creation_rewrites(
                 continue;
             }
             let signal_name = match operation {
-                EmitOperation::CreateReactive { name, helper, .. }
-                    if matches!(helper, RuntimeHelper::Signal | RuntimeHelper::UseSignal) =>
-                {
-                    name
-                }
+                EmitOperation::CreateReactive {
+                    name,
+                    helper: RuntimeHelper::Signal | RuntimeHelper::UseSignal,
+                    ..
+                } => name,
                 _ => &None,
             }
             .clone();

--- a/crates/fict-compiler-oxc/src/emit_codegen/conditional_return.rs
+++ b/crates/fict-compiler-oxc/src/emit_codegen/conditional_return.rs
@@ -1,0 +1,181 @@
+use super::{block_iife, const_statement, zero_parameter_expression_arrow};
+use oxc::{
+    allocator::{Allocator, CloneIn, Vec as ArenaVec},
+    ast::{
+        AstBuilder, NONE,
+        ast::{Argument, Expression, IdentifierName, Statement},
+    },
+    span::Span,
+};
+use std::collections::{BTreeMap, BTreeSet};
+#[derive(Debug, Clone)]
+pub(super) struct ConditionalReturnRewrite {
+    target: String,
+    helper: String,
+    create_helper: String,
+    cleanup_helper: String,
+}
+impl ConditionalReturnRewrite {
+    pub(super) fn new(target: &str, helper: &str, create: &str, cleanup: &str) -> Self {
+        Self {
+            target: target.to_owned(),
+            helper: helper.to_owned(),
+            create_helper: create.to_owned(),
+            cleanup_helper: cleanup.to_owned(),
+        }
+    }
+}
+pub(super) fn lower_statements<'a>(
+    allocator: &'a Allocator,
+    statements: &mut ArenaVec<'a, Statement<'a>>,
+    rewrites: &BTreeMap<(u32, u32), ConditionalReturnRewrite>,
+    matched: &mut BTreeSet<(u32, u32)>,
+    await_allowed: bool,
+) {
+    let mut index = 0;
+    while index < statements.len() {
+        if let Statement::ReturnStatement(returned) = &statements[index]
+            && let Some(Expression::ConditionalExpression(conditional)) = &returned.argument
+        {
+            let location = (conditional.span.start, conditional.span.end);
+            if let Some(rewrite) = rewrites.get(&location) {
+                let replacement = binding_expression(
+                    allocator,
+                    rewrite,
+                    conditional.test.clone_in(allocator),
+                    conditional.consequent.clone_in(allocator),
+                    conditional.alternate.clone_in(allocator),
+                    returned.span,
+                    await_allowed,
+                );
+                statements[index] = Statement::new_return_statement(
+                    returned.span,
+                    Some(replacement),
+                    &AstBuilder::new(allocator),
+                );
+                matched.insert(location);
+                index += 1;
+                continue;
+            }
+        }
+        let Statement::IfStatement(statement) = &statements[index] else {
+            index += 1;
+            continue;
+        };
+        let location = (statement.span.start, statement.span.end);
+        let Some(rewrite) = rewrites.get(&location) else {
+            index += 1;
+            continue;
+        };
+        let Some(consequent) = return_argument(allocator, &statement.consequent) else {
+            index += 1;
+            continue;
+        };
+        let (alternate, remove_next) = if let Some(alternate) = &statement.alternate {
+            (return_argument(allocator, alternate), false)
+        } else {
+            (
+                statements
+                    .get(index + 1)
+                    .and_then(|next| return_argument(allocator, next)),
+                true,
+            )
+        };
+        let Some(alternate) = alternate else {
+            index += 1;
+            continue;
+        };
+        let test = statement.test.clone_in(allocator);
+        let replacement = binding_expression(
+            allocator,
+            rewrite,
+            test,
+            consequent,
+            alternate,
+            statement.span,
+            await_allowed,
+        );
+        statements[index] = Statement::new_return_statement(
+            statement.span,
+            Some(replacement),
+            &AstBuilder::new(allocator),
+        );
+        if remove_next {
+            statements.remove(index + 1);
+        }
+        matched.insert(location);
+        index += 1;
+    }
+}
+fn return_argument<'a>(
+    allocator: &'a Allocator,
+    statement: &Statement<'a>,
+) -> Option<Expression<'a>> {
+    let returned = match statement {
+        Statement::ReturnStatement(returned) => returned,
+        Statement::BlockStatement(block) if block.body.len() == 1 => {
+            let Statement::ReturnStatement(returned) = &block.body[0] else {
+                return None;
+            };
+            returned
+        }
+        _ => return None,
+    };
+    returned
+        .argument
+        .as_ref()
+        .map(|value| value.clone_in(allocator))
+}
+fn binding_expression<'a>(
+    allocator: &'a Allocator,
+    rewrite: &ConditionalReturnRewrite,
+    test: Expression<'a>,
+    consequent: Expression<'a>,
+    alternate: Expression<'a>,
+    span: Span,
+    await_allowed: bool,
+) -> Expression<'a> {
+    let builder = AstBuilder::new(allocator);
+    let callee = Expression::new_identifier(span, allocator.alloc_str(&rewrite.helper), &builder);
+    let create =
+        Expression::new_identifier(span, allocator.alloc_str(&rewrite.create_helper), &builder);
+    let mut arguments = ArenaVec::new_in(&allocator);
+    arguments.extend(
+        [test, consequent, alternate]
+            .into_iter()
+            .map(|value| Argument::from(zero_parameter_expression_arrow(allocator, value, span))),
+    );
+    arguments.insert(2, Argument::from(create));
+    let binding = Expression::new_call_expression(span, callee, NONE, arguments, false, &builder);
+    let mut body = ArenaVec::new_in(&allocator);
+    body.push(const_statement(allocator, &rewrite.target, binding, span));
+    let target = Expression::new_identifier(span, allocator.alloc_str(&rewrite.target), &builder);
+    let dispose = Expression::new_static_member_expression(
+        span,
+        target,
+        IdentifierName::new(span, "dispose", &builder),
+        false,
+        &builder,
+    );
+    let cleanup =
+        Expression::new_identifier(span, allocator.alloc_str(&rewrite.cleanup_helper), &builder);
+    let cleanup = Expression::new_call_expression(
+        span,
+        cleanup,
+        NONE,
+        ArenaVec::from_array_in([Argument::from(dispose)], &allocator),
+        false,
+        &builder,
+    );
+    body.push(Statement::new_expression_statement(span, cleanup, &builder));
+    body.push(Statement::new_return_statement(
+        span,
+        Some(Expression::new_identifier(
+            span,
+            allocator.alloc_str(&rewrite.target),
+            &builder,
+        )),
+        &builder,
+    ));
+    block_iife(allocator, body, span, await_allowed)
+}

--- a/crates/fict-compiler-oxc/src/hir_builder.rs
+++ b/crates/fict-compiler-oxc/src/hir_builder.rs
@@ -3972,6 +3972,8 @@ impl<'source, 'semantic> Builder<'source, 'semantic> {
         span: SourceSpan,
         referenced_bindings: Vec<BindingId>,
     ) -> ValueId {
+        let block = self.planned_block_for_span(owner, span);
+        let inputs = self.instruction_inputs_for_spans(owner, block, &[span], true);
         let fragment = self.add_fragment(
             SyntaxFragmentKind::Expression,
             span,
@@ -3982,14 +3984,12 @@ impl<'source, 'semantic> Builder<'source, 'semantic> {
                 ..SyntaxSummary::default()
             },
         );
-        self.push_value(
+        self.push_value_to_block(
             owner,
+            block,
             ValueKind::SyntaxFragment(fragment),
             Origin::source(span),
-            HirInstructionKind::SyntaxFragment {
-                fragment,
-                inputs: Vec::new(),
-            },
+            HirInstructionKind::SyntaxFragment { fragment, inputs },
             InstructionSemantics::CONSERVATIVE_EAGER,
         )
     }

--- a/crates/fict-compiler-oxc/src/preview_codegen.rs
+++ b/crates/fict-compiler-oxc/src/preview_codegen.rs
@@ -327,6 +327,7 @@ pub(crate) fn generate_handler_artifact<'a>(
     let mut program = parsed.program;
     program.source_type = source_type;
     ZeroSpans.visit_program(&mut program);
+    program.source_text = source;
     let expected_prop_defaults = prepared
         .plan
         .prop_captures

--- a/crates/fict-compiler-oxc/tests/hir_builder.rs
+++ b/crates/fict-compiler-oxc/tests/hir_builder.rs
@@ -1753,13 +1753,7 @@ fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
             .find(|instruction| authored(instruction) == text)
             .unwrap_or_else(|| panic!("instruction for {text}"))
     };
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for {value:?}"))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals
@@ -1956,13 +1950,7 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
             .as_deref()
             .expect("named local")
     };
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for {value:?}"))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals
@@ -2870,13 +2858,7 @@ fn materializes_exact_utf16_strings_and_template_quasis() {
         .iter()
         .flat_map(|block| &block.instructions)
         .collect();
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals
@@ -3099,13 +3081,7 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
         }
     }
 
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals
@@ -4814,13 +4790,7 @@ fn materializes_sequence_values_in_authored_evaluation_order() {
             .expect("authored sequence instruction");
         &source[span.start() as usize..span.end() as usize]
     };
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let local = |name: &str| {
         function
             .locals
@@ -4962,13 +4932,7 @@ fn materializes_template_quasis_coercions_and_lazy_ownership() {
             .expect("authored template instruction");
         &source[span.start() as usize..span.end() as usize]
     };
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals
@@ -5095,13 +5059,7 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
             .expect("authored tagged-template instruction");
         &source[span.start() as usize..span.end() as usize]
     };
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let local = |name: &str| {
         function
             .locals
@@ -5328,13 +5286,7 @@ fn materializes_dynamic_import_phases_options_and_coercion_order() {
             .expect("authored dynamic-import instruction");
         &source[span.start() as usize..span.end() as usize]
     };
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals
@@ -6113,13 +6065,7 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
         .iter()
         .flat_map(|block| &block.instructions)
         .collect();
-    let instruction_for_result = |value| {
-        instructions
-            .iter()
-            .copied()
-            .find(|instruction| instruction.result == Some(value))
-            .unwrap_or_else(|| panic!("instruction for value{}", value.index()))
-    };
+    let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
             .locals

--- a/crates/fict-compiler-oxc/tests/hir_builder.rs
+++ b/crates/fict-compiler-oxc/tests/hir_builder.rs
@@ -17,7 +17,6 @@ use fict_reactivity::{
     ReactiveBindingKind, SsaDefinitionKind, analyze_aliases, analyze_dependencies,
     analyze_reactive_scopes, analyze_shapes, analyze_ssa,
 };
-
 fn options(language: OxcSourceLanguage) -> OxcCompileOptions {
     OxcCompileOptions {
         language,
@@ -26,7 +25,6 @@ fn options(language: OxcSourceLanguage) -> OxcCompileOptions {
         sourcemap: false,
     }
 }
-
 #[test]
 fn annotates_direct_and_namespace_imports_from_exact_resolved_metadata() {
     let output = build_hir(
@@ -150,7 +148,6 @@ fn annotates_direct_and_namespace_imports_from_exact_resolved_metadata() {
             .as_ref()
             .and_then(|import| import.reactive)
     };
-
     assert_eq!(reactive("primary"), Some(ImportedReactiveKind::Signal));
     assert_eq!(reactive("localCount"), Some(ImportedReactiveKind::Signal));
     assert_eq!(reactive("doubled"), Some(ImportedReactiveKind::Memo));
@@ -177,7 +174,6 @@ fn annotates_direct_and_namespace_imports_from_exact_resolved_metadata() {
             }],
         })
     );
-
     let members = |name: &str| {
         hir.bindings
             .iter()
@@ -245,7 +241,6 @@ fn annotates_direct_and_namespace_imports_from_exact_resolved_metadata() {
             .map(|property| (property.key.as_str(), property.kind)),
         Some(("0", ImportedReactiveKind::Memo))
     );
-
     let app = hir
         .functions
         .iter()
@@ -300,7 +295,6 @@ fn annotates_direct_and_namespace_imports_from_exact_resolved_metadata() {
     assert_eq!(static_path(calls[2]), ["deep", "usePair"]);
     assert_eq!(static_path(calls[3]), ["<dynamic>"]);
 }
-
 #[test]
 fn remaps_owned_module_exports_after_typescript_runtime_erasure() {
     let output = build_hir(
@@ -318,7 +312,6 @@ fn remaps_owned_module_exports_after_typescript_runtime_erasure() {
     let hir = output.hir.expect("verified HIR");
     let module_plan = output.module_plan.expect("verified module plan");
     verify_module_plan(&hir, &module_plan).expect("module plan must own valid HIR identities");
-
     let value = hir
         .bindings
         .iter()
@@ -347,7 +340,6 @@ fn remaps_owned_module_exports_after_typescript_runtime_erasure() {
             if exported == "forwarded" && source == "./dep"
     ));
 }
-
 #[test]
 fn retains_simple_explicit_and_arrow_return_values_in_terminators() {
     let output = build_hir(
@@ -371,7 +363,6 @@ fn retains_simple_explicit_and_arrow_return_values_in_terminators() {
             })
             .unwrap_or_else(|| panic!("missing function {name}"))
     };
-
     for name in ["useObject", "read"] {
         let function = named(name);
         let TerminatorKind::Return { value: Some(value) } = function.blocks[0].terminator.kind
@@ -390,7 +381,6 @@ fn retains_simple_explicit_and_arrow_return_values_in_terminators() {
         TerminatorKind::Return { value: None }
     ));
 }
-
 #[test]
 fn lowers_if_returns_into_real_hir_blocks_with_control_dependencies() {
     let source = r#"
@@ -413,7 +403,6 @@ fn lowers_if_returns_into_real_hir_blocks_with_control_dependencies() {
         .iter()
         .find(|function| function.kind == FunctionKind::Component)
         .expect("component function");
-
     assert_eq!(app.blocks.len(), 4);
     let source_hint = app.blocks[0]
         .source_hint
@@ -491,7 +480,6 @@ fn lowers_if_returns_into_real_hir_blocks_with_control_dependencies() {
                 } if left == reactive_read
             )
     }));
-
     let consequent_block = &app.blocks[consequent.as_usize()];
     let TerminatorKind::Return {
         value: Some(big_value),
@@ -503,7 +491,6 @@ fn lowers_if_returns_into_real_hir_blocks_with_control_dependencies() {
         instruction.result == Some(big_value)
             && matches!(instruction.kind, HirInstructionKind::Jsx { .. })
     }));
-
     let TerminatorKind::Goto { target: join } = app.blocks[alternate.as_usize()].terminator.kind
     else {
         panic!("empty false branch must flow to the join")
@@ -530,7 +517,6 @@ fn lowers_if_returns_into_real_hir_blocks_with_control_dependencies() {
         )
     );
 }
-
 #[test]
 fn lowers_throw_values_into_their_conditional_block() {
     let source = r#"
@@ -568,7 +554,6 @@ fn lowers_throw_values_into_their_conditional_block() {
         instruction.result == Some(value) && matches!(instruction.kind, HirInstructionKind::Call(_))
     }));
 }
-
 #[test]
 fn lowers_switch_tests_fallthrough_and_breaks_in_exact_evaluation_order() {
     let source = r#"
@@ -606,7 +591,6 @@ fn lowers_switch_tests_fallthrough_and_breaks_in_exact_evaluation_order() {
         .iter()
         .find(|function| function.binding == Some(work))
         .expect("work function");
-
     let header = function
         .blocks
         .iter()
@@ -627,7 +611,6 @@ fn lowers_switch_tests_fallthrough_and_breaks_in_exact_evaluation_order() {
         1
     );
     assert!(hint.exit.is_some());
-
     let test_blocks: Vec<_> = hint
         .switch_cases
         .iter()
@@ -638,7 +621,6 @@ fn lowers_switch_tests_fallthrough_and_breaks_in_exact_evaluation_order() {
         header.terminator.kind,
         TerminatorKind::Goto { target } if target == test_blocks[0]
     ));
-
     let comparisons: Vec<_> = test_blocks
         .iter()
         .map(|block| {
@@ -711,7 +693,6 @@ fn lowers_switch_tests_fallthrough_and_breaks_in_exact_evaluation_order() {
                     ))
         );
     }
-
     assert!(matches!(
         function.blocks[hint.switch_cases[1].body.as_usize()]
             .terminator
@@ -745,7 +726,6 @@ fn lowers_switch_tests_fallthrough_and_breaks_in_exact_evaluation_order() {
             })
     );
 }
-
 #[test]
 fn lowers_try_catch_finally_and_catch_patterns_into_structured_cfg() {
     let source = r#"
@@ -828,7 +808,6 @@ fn lowers_try_catch_finally_and_catch_patterns_into_structured_cfg() {
             .map(|hint| &hint.kind),
         Some(StructuredSourceKind::Finally)
     ));
-
     for (call, expected_block) in [
         ("action()", body),
         ("fallbackMessage()", catch),
@@ -848,7 +827,6 @@ fn lowers_try_catch_finally_and_catch_patterns_into_structured_cfg() {
             .unwrap_or_else(|| panic!("missing {call}"));
         assert_eq!(block.id, expected_block, "{call}");
     }
-
     let catch_block = &function.blocks[catch.as_usize()];
     let fallback_value = catch_block
         .instructions
@@ -925,7 +903,6 @@ fn lowers_try_catch_finally_and_catch_patterns_into_structured_cfg() {
             })
     );
 }
-
 #[test]
 fn lowers_catch_only_and_finally_only_try_variants() {
     let source = r#"
@@ -992,7 +969,6 @@ fn lowers_catch_only_and_finally_only_try_variants() {
         }
     }
 }
-
 #[test]
 fn lowers_classic_loops_and_labeled_control_edges() {
     let source = r#"
@@ -1031,7 +1007,6 @@ fn lowers_classic_loops_and_labeled_control_edges() {
         .iter()
         .find(|function| function.binding == Some(loops))
         .expect("loops function");
-
     let loop_headers: Vec<_> = function
         .blocks
         .iter()
@@ -1077,7 +1052,6 @@ fn lowers_classic_loops_and_labeled_control_edges() {
         })
         .expect("for update block")
         .id;
-
     let terminator_for = |text: &str| {
         function.blocks.iter().find_map(|block| {
             let span = block.terminator.origin.primary_span?;
@@ -1104,7 +1078,6 @@ fn lowers_classic_loops_and_labeled_control_edges() {
         Some(TerminatorKind::Goto { target }) if Some(*target) == do_while_loop.1.exit
     ));
 }
-
 #[test]
 fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targets() {
     let source = r#"
@@ -1143,7 +1116,6 @@ fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targe
         .iter()
         .find(|function| function.binding == Some(iterate))
         .expect("iterate function");
-
     let headers: Vec<_> = function
         .blocks
         .iter()
@@ -1159,7 +1131,6 @@ fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targe
         })
         .collect();
     assert_eq!(headers.len(), 3, "{headers:#?}");
-
     let binding = |name: &str| {
         hir.bindings
             .iter()
@@ -1179,7 +1150,6 @@ fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targe
     let item = local("item");
     let value = local("value");
     let rest = local("rest");
-
     for header in &headers {
         let (kind, source_value, body, exit) = match header.terminator.kind {
             TerminatorKind::ForIn { object, body, exit } => (IterationKind::In, object, body, exit),
@@ -1219,7 +1189,6 @@ fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targe
             source_block.terminator.kind,
             TerminatorKind::Goto { target } if target == header.id
         ));
-
         let iteration = function.blocks[body.as_usize()]
             .instructions
             .iter()
@@ -1257,7 +1226,6 @@ fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targe
             }
         }
     }
-
     let terminator_for = |text: &str| {
         function.blocks.iter().find_map(|block| {
             let span = block.terminator.origin.primary_span?;
@@ -1288,7 +1256,6 @@ fn lowers_for_in_of_and_await_of_with_once_evaluated_sources_and_iteration_targe
         Some(TerminatorKind::Goto { target }) if *target == await_of.id
     ));
 }
-
 #[test]
 fn builds_verified_binding_aware_hir_for_tsx_components_and_macros() {
     let source = r#"
@@ -1305,7 +1272,6 @@ fn builds_verified_binding_aware_hir_for_tsx_components_and_macros() {
     );
     assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
     let hir = output.hir.expect("verified HIR");
-
     let app = hir
         .functions
         .iter()
@@ -1372,7 +1338,6 @@ fn builds_verified_binding_aware_hir_for_tsx_components_and_macros() {
             .any(|instruction| matches!(instruction.kind, HirInstructionKind::Jsx { .. }))
     );
 }
-
 #[test]
 fn alias_and_shadow_calls_keep_distinct_binding_identity() {
     let source = r#"
@@ -1410,7 +1375,6 @@ fn alias_and_shadow_calls_keep_distinct_binding_identity() {
     };
     assert_ne!(imported, shadow);
 }
-
 #[test]
 fn classifies_runtime_reactive_calls_by_import_identity() {
     let source = r#"
@@ -1419,7 +1383,6 @@ fn classifies_runtime_reactive_calls_by_import_identity() {
         import { createSelector as selector } from '@fictjs/runtime/advanced';
         import * as F from 'fict';
         import { $store as fakeStore } from 'third-party';
-
         const one = store({ value: 1 });
         const two = resource(() => 2);
         const three = selector(() => 3);
@@ -1470,7 +1433,6 @@ fn classifies_runtime_reactive_calls_by_import_identity() {
         "wrong-module and shadowed same-name calls remain ordinary"
     );
 }
-
 #[test]
 fn materializes_binding_resolved_macro_reads_in_hir() {
     let source = r#"
@@ -1503,7 +1465,6 @@ fn materializes_binding_resolved_macro_reads_in_hir() {
             )
         })
         .collect();
-
     assert_eq!(reads.len(), 2);
     for read in reads {
         let span = read.origin.primary_span.expect("read source span");
@@ -1535,7 +1496,6 @@ fn materializes_binding_resolved_macro_reads_in_hir() {
         Some("doubled")
     );
 }
-
 #[test]
 fn materializes_reactive_assignments_compounds_and_updates() {
     let source = r#"
@@ -1578,7 +1538,6 @@ fn materializes_reactive_assignments_compounds_and_updates() {
             _ => false,
         })
         .collect();
-
     assert_eq!(mutations.len(), 4);
     assert!(
         mutations
@@ -1664,7 +1623,6 @@ fn materializes_reactive_assignments_compounds_and_updates() {
         }),
         "ordinary assignment expressions must not fall back to syntax fragments"
     );
-
     let shadow = hir
         .functions
         .iter()
@@ -1704,7 +1662,6 @@ fn materializes_reactive_assignments_compounds_and_updates() {
         ["count += 1", "count++"]
     );
 }
-
 #[test]
 fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
     let source = r#"
@@ -1772,7 +1729,6 @@ fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
             })
             .unwrap_or_else(|| panic!("{name} initializer"))
     };
-
     let assignment_roots: Vec<_> = [
         "simple",
         "projected",
@@ -1804,13 +1760,11 @@ fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
             ]
             .contains(&authored(instruction))
     }));
-
     let simple = instruction_for_result(initializer("simple"));
     let HirInstructionKind::Write { value, .. } = simple.kind else {
         panic!("simple assignment must be a typed write")
     };
     assert_eq!(authored(instruction_for_result(value)), "make('simple')");
-
     let projected = instruction_for_result(initializer("projected"));
     let HirInstructionKind::Write { place, value } = &projected.kind else {
         panic!("projected assignment must be a typed write")
@@ -1845,7 +1799,6 @@ fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
     };
     assert!(position(*key) < position(*value));
     assert!(position(*value) < position(projected.result.expect("projected result")));
-
     for (name, operator, rhs) in [
         (
             "andResult",
@@ -1896,7 +1849,6 @@ fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
             "plain assignment RHS must remain eager: {text}"
         );
     }
-
     let argument_assignment = instruction("value = make('argument')");
     let argument_result = argument_assignment
         .result
@@ -1908,7 +1860,6 @@ fn preserves_assignment_results_projected_order_and_logical_rhs_laziness() {
     assert_eq!(call.arguments.len(), 1);
     assert_eq!(call.arguments[0].value, argument_result);
 }
-
 #[test]
 fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
     let source = r#"
@@ -1969,7 +1920,6 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
             })
             .unwrap_or_else(|| panic!("{name} initializer"))
     };
-
     let assignments: Vec<_> = instructions
         .iter()
         .copied()
@@ -1996,7 +1946,6 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
             .iter()
             .all(|instruction| instruction.result.is_some())
     );
-
     let first = assignments[0];
     let HirInstructionKind::PatternAssignment {
         value: first_value,
@@ -2050,7 +1999,6 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
             .collect::<Vec<_>>(),
         ["key", "fallback"]
     );
-
     let second = assignments[1];
     let HirInstructionKind::PatternAssignment {
         value: second_value,
@@ -2100,7 +2048,6 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
         initializer("argument"),
         invocation.result.expect("call result")
     );
-
     for deferred in ["key()", "fallback()", "object.slot"] {
         assert!(
             instructions
@@ -2121,7 +2068,6 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
                     .contains(&authored(instruction.origin))
         )
     }));
-
     let ssa = analyze_ssa(function).expect("destructuring-assignment SSA");
     assert_eq!(
         ssa.definitions
@@ -2133,7 +2079,6 @@ fn materializes_destructuring_assignments_as_typed_result_bearing_hir() {
     );
     analyze_dependencies(&hir, function.id, &ssa).expect("destructuring-assignment dependencies");
 }
-
 #[test]
 fn plain_assignment_results_do_not_escape_reactive_pattern_targets() {
     let source = r#"
@@ -2160,7 +2105,6 @@ fn plain_assignment_results_do_not_escape_reactive_pattern_targets() {
         output.diagnostics
     );
 }
-
 #[test]
 fn propagates_reactive_dependencies_through_pattern_defaults() {
     let source = r#"
@@ -2216,7 +2160,6 @@ fn propagates_reactive_dependencies_through_pattern_defaults() {
     assert!(derived.dependencies.iter().any(|path| {
         matches!(path.base, fict_reactivity::DependencyBase::Ssa(name) if name.local == state)
     }));
-
     let escaped_source = r#"
             import { $state } from 'fict';
             function App(consume) {
@@ -2238,7 +2181,6 @@ fn propagates_reactive_dependencies_through_pattern_defaults() {
                 &escaped_source[span.start() as usize..span.end() as usize] == "derived"
             })
     }));
-
     let callback_default = build_hir(
         r#"
             import { $state } from 'fict';
@@ -2257,7 +2199,6 @@ fn propagates_reactive_dependencies_through_pattern_defaults() {
         diagnostic.code.as_str() == "FICT-R005" && diagnostic.message.contains("state")
     }));
 }
-
 #[test]
 fn escape_diagnostics_keep_direct_props_roots_without_propagating_props_locals() {
     let accepted = build_hir(
@@ -2282,7 +2223,6 @@ fn escape_diagnostics_keep_direct_props_roots_without_propagating_props_locals()
             .iter()
             .all(|diagnostic| { !matches!(diagnostic.code.as_str(), "FICT-R002" | "FICT-R005") })
     );
-
     let direct_props = build_hir(
         r#"
             export function App(props) {
@@ -2301,7 +2241,6 @@ fn escape_diagnostics_keep_direct_props_roots_without_propagating_props_locals()
             .any(|diagnostic| diagnostic.code.as_str() == "FICT-R002")
     );
 }
-
 #[test]
 fn materializes_plain_local_accesses_in_dependency_safe_source_order() {
     let source = r#"
@@ -2329,7 +2268,6 @@ fn materializes_plain_local_accesses_in_dependency_safe_source_order() {
                 .is_some_and(|binding| hir.bindings[binding.as_usize()].display_name == "plain")
         })
         .expect("plain function");
-
     let input = plain
         .locals
         .iter()
@@ -2354,7 +2292,6 @@ fn materializes_plain_local_accesses_in_dependency_safe_source_order() {
                 if place == &fict_hir::Place::local(value.id)
         )
     }));
-
     let ordered_effects: Vec<_> = plain.blocks[0]
         .instructions
         .iter()
@@ -2392,7 +2329,6 @@ fn materializes_plain_local_accesses_in_dependency_safe_source_order() {
             && instruction.semantics.purity == Purity::Impure
     }));
 }
-
 #[test]
 fn materializes_variable_initializers_and_opaque_destructuring_in_semantic_order() {
     let source = r#"
@@ -2448,7 +2384,6 @@ fn materializes_variable_initializers_and_opaque_destructuring_in_semantic_order
             .and_then(|instruction| instruction.result)
             .unwrap_or_else(|| panic!("result for {text}"))
     };
-
     let from_var = local("fromVar");
     let (var_declaration_block, var_initializer) = function
         .blocks
@@ -2479,7 +2414,6 @@ fn materializes_variable_initializers_and_opaque_destructuring_in_semantic_order
             )
         })
     }));
-
     let from_let = local("fromLet");
     let let_value = find_result("effect('let')");
     let (let_block, let_call_index, let_declaration_index) = function
@@ -2505,7 +2439,6 @@ fn materializes_variable_initializers_and_opaque_destructuring_in_semantic_order
         .expect("let declaration linked to its initializer");
     assert_ne!(let_block, function.entry);
     assert!(let_call_index < let_declaration_index);
-
     let from_member = local("fromMember");
     let member_value = find_result("input.value");
     assert!(function.blocks.iter().any(|block| {
@@ -2520,7 +2453,6 @@ fn materializes_variable_initializers_and_opaque_destructuring_in_semantic_order
             )
         })
     }));
-
     let fallback_calls = function
         .blocks
         .iter()
@@ -2600,7 +2532,6 @@ fn materializes_variable_initializers_and_opaque_destructuring_in_semantic_order
         }));
     }
 }
-
 #[test]
 fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
     let source = r#"
@@ -2657,7 +2588,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
             .and_then(|instruction| instruction.result)
             .unwrap_or_else(|| panic!("typed result for {text}"))
     };
-
     let zero = typed_result("0");
     assert!(matches!(
         function.values[zero.as_usize()].kind,
@@ -2674,7 +2604,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
                 } if argument == zero
             )
     }));
-
     let multiply = typed_result("2 * 3");
     let arithmetic = typed_result("0x10 + 2 * 3");
     assert!(instructions.iter().any(|instruction| {
@@ -2698,7 +2627,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
                 } if right == multiply
             )
     }));
-
     let exact = instructions
         .iter()
         .find(|instruction| authored(instruction) == "input === null")
@@ -2725,7 +2653,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
     assert_eq!(loose.semantics.purity, Purity::Unknown);
     assert_eq!(loose.semantics.mutation, MutationEffect::Unknown);
     assert!(loose.semantics.may_throw);
-
     for (text, operator) in [
         ("!input", UnaryOperator::Not),
         ("void side()", UnaryOperator::Void),
@@ -2743,7 +2670,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
         ));
         assert_eq!(unary.semantics, fict_hir::InstructionSemantics::PURE_EAGER);
     }
-
     let literals: Vec<_> = instructions
         .iter()
         .filter_map(|instruction| match &instruction.kind {
@@ -2771,7 +2697,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
             .iter()
             .any(|(text, literal)| { *text == "true" && *literal == &LiteralValue::Boolean(true) })
     );
-
     for name in [
         "negativeZero",
         "arithmetic",
@@ -2800,7 +2725,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
             )
         }));
     }
-
     let branch = hir
         .functions
         .iter()
@@ -2824,7 +2748,6 @@ fn materializes_literals_unary_and_binary_expressions_as_typed_values() {
             )
     }));
 }
-
 #[test]
 fn materializes_exact_utf16_strings_and_template_quasis() {
     let source = r#"
@@ -2884,12 +2807,10 @@ fn materializes_exact_utf16_strings_and_template_quasis() {
         };
         value
     };
-
     assert_eq!(literal("high").as_code_units(), &[0xd800]);
     assert_eq!(literal("lowTemplate").as_code_units(), &[0xdfff]);
     assert_eq!(literal("mixed").as_code_units(), &[0xfffd, 0xd800]);
     assert_eq!(literal("astral").as_code_units(), &[0xd83d, 0xde00]);
-
     let dynamic = instruction_for_result(initializer("dynamic"));
     let HirInstructionKind::TemplateLiteral {
         quasis,
@@ -2904,7 +2825,6 @@ fn materializes_exact_utf16_strings_and_template_quasis() {
     let expected_tail =
         JavaScriptString::from_code_units(vec![0xdc00]).concat(&JavaScriptString::from(" right"));
     assert_eq!(quasis, &[expected_head, expected_tail]);
-
     for name in ["high", "lowTemplate", "mixed", "astral", "dynamic"] {
         let root = instruction_for_result(initializer(name));
         assert!(
@@ -2913,7 +2833,6 @@ fn materializes_exact_utf16_strings_and_template_quasis() {
         );
     }
 }
-
 #[test]
 fn distinguishes_unresolved_typeof_from_binding_reads() {
     let source = r#"
@@ -2953,7 +2872,6 @@ fn distinguishes_unresolved_typeof_from_binding_reads() {
             .expect("authored typeof expression");
         &source[span.start() as usize..span.end() as usize]
     };
-
     for identifier in ["definitelyMissing", "console"] {
         let instruction = instructions
             .iter()
@@ -2971,7 +2889,6 @@ fn distinguishes_unresolved_typeof_from_binding_reads() {
             fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
         );
     }
-
     let bound = instructions
         .iter()
         .find(|instruction| authored(instruction) == "typeof local")
@@ -2984,7 +2901,6 @@ fn distinguishes_unresolved_typeof_from_binding_reads() {
         }
     ));
     assert_eq!(bound.semantics, fict_hir::InstructionSemantics::PURE_EAGER);
-
     for name in ["absent", "host", "bound"] {
         let local = function
             .locals
@@ -3012,7 +2928,6 @@ fn distinguishes_unresolved_typeof_from_binding_reads() {
         );
     }
 }
-
 #[test]
 fn materializes_this_new_target_and_import_meta_as_context_values() {
     let source = r#"
@@ -3050,7 +2965,6 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
         .iter()
         .flat_map(|block| &block.instructions)
         .collect();
-
     for (kind, authored, expected_count) in [
         (ContextValueKind::This, "this", 2),
         (ContextValueKind::Arguments, "arguments", 2),
@@ -3080,7 +2994,6 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
             }
         }
     }
-
     let instruction_for_result = |value| function.instruction_for_result(value).unwrap();
     let initializer = |name: &str| {
         let local = function
@@ -3100,7 +3013,6 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
             })
             .unwrap_or_else(|| panic!("{name} initializer"))
     };
-
     for (name, kind) in [
         ("receiver", ContextValueKind::This),
         ("args", ContextValueKind::Arguments),
@@ -3130,7 +3042,6 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
             HirInstructionKind::Context { kind: candidate } if candidate == kind
         ));
     }
-
     for name in [
         "receiver",
         "args",
@@ -3149,7 +3060,6 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
             "{name} must not fall back to adapter-owned syntax"
         );
     }
-
     let nested = hir
         .functions
         .iter()
@@ -3184,7 +3094,6 @@ fn materializes_this_new_target_and_import_meta_as_context_values() {
         "arrow-owned context values retain lexical function form"
     );
 }
-
 #[test]
 fn keeps_module_and_shadowed_arguments_outside_function_context_values() {
     let source = r#"
@@ -3226,7 +3135,6 @@ fn keeps_module_and_shadowed_arguments_outside_function_context_values() {
                 } if global == arguments_global
             ))
     );
-
     let shadow = hir
         .functions
         .iter()
@@ -3264,7 +3172,6 @@ fn keeps_module_and_shadowed_arguments_outside_function_context_values() {
             ))
     );
 }
-
 #[test]
 fn materializes_logical_and_conditional_expressions_with_lazy_arms() {
     let source = r#"
@@ -3313,7 +3220,6 @@ fn materializes_logical_and_conditional_expressions_with_lazy_arms() {
             .find(|instruction| authored(instruction) == text)
             .unwrap_or_else(|| panic!("instruction for {text}"))
     };
-
     for text in [
         "inspect('and-left', input)",
         "inspect('or-left', input)",
@@ -3348,7 +3254,6 @@ fn materializes_logical_and_conditional_expressions_with_lazy_arms() {
             "short-circuit arms must stay lazy: {text}"
         );
     }
-
     for (text, operator, left, right) in [
         (
             "inspect('and-left', input) && fallback('and-right')",
@@ -3382,7 +3287,6 @@ fn materializes_logical_and_conditional_expressions_with_lazy_arms() {
         ));
         assert_eq!(root.semantics, fict_hir::InstructionSemantics::PURE_EAGER);
     }
-
     let conditional = instructions
         .iter()
         .copied()
@@ -3414,7 +3318,6 @@ fn materializes_logical_and_conditional_expressions_with_lazy_arms() {
         conditional.semantics,
         fict_hir::InstructionSemantics::PURE_EAGER
     );
-
     for (name, expected) in [
         ("andValue", BinaryOperator::LogicalAnd),
         ("orValue", BinaryOperator::LogicalOr),
@@ -3463,7 +3366,6 @@ fn materializes_logical_and_conditional_expressions_with_lazy_arms() {
         )
     }));
 }
-
 #[test]
 fn materializes_array_holes_spreads_and_element_evaluation_order() {
     let source = r#"
@@ -3510,7 +3412,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
             .find(|instruction| authored(instruction) == text)
             .unwrap_or_else(|| panic!("instruction for {text}"))
     };
-
     let dense = instruction("[1, make('second'), input.value]");
     let HirInstructionKind::Array {
         elements: dense_elements,
@@ -3525,7 +3426,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
     assert!(matches!(dense_elements[2], ArrayElement::Value(value)
         if Some(value) == instruction("input.value").result));
     assert_eq!(dense.semantics, fict_hir::InstructionSemantics::PURE_EAGER);
-
     let sparse = instruction("[, 1, ,]");
     let HirInstructionKind::Array {
         elements: sparse_elements,
@@ -3537,7 +3437,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
     assert!(matches!(sparse_elements[0], ArrayElement::Hole(_)));
     assert!(matches!(sparse_elements[1], ArrayElement::Value(_)));
     assert!(matches!(sparse_elements[2], ArrayElement::Hole(_)));
-
     let spread = instruction("[make('before'), ...make('spread'), make('after'), , ...tail]");
     let HirInstructionKind::Array {
         elements: spread_elements,
@@ -3576,7 +3475,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
             "the array node owns evaluation from its first spread: {text}"
         );
     }
-
     let ordered_calls: Vec<_> = instructions
         .iter()
         .filter(|instruction| matches!(instruction.kind, HirInstructionKind::Call(_)))
@@ -3591,7 +3489,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
             "make('after')",
         ]
     );
-
     let nodes = instruction("[<div />, input ? <span /> : <p />]");
     let HirInstructionKind::Array {
         elements: node_elements,
@@ -3623,7 +3520,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
         instruction("<p />").semantics.evaluation,
         EvaluationMode::Deferred
     );
-
     for (name, value) in [
         ("dense", dense),
         ("sparse", sparse),
@@ -3647,7 +3543,6 @@ fn materializes_array_holes_spreads_and_element_evaluation_order() {
         }));
     }
 }
-
 #[test]
 fn materializes_object_keys_entries_and_definition_order() {
     let source = r#"
@@ -3734,7 +3629,6 @@ fn materializes_object_keys_entries_and_definition_order() {
             .find(|instruction| instruction.result == Some(initializer))
             .unwrap_or_else(|| panic!("{name} object instruction"))
     };
-
     let plain = object_for_local("plain");
     let HirInstructionKind::Object {
         entries: plain_entries,
@@ -3800,7 +3694,6 @@ fn materializes_object_keys_entries_and_definition_order() {
             .evaluation,
         EvaluationMode::Eager
     );
-
     let complex = object_for_local("complex");
     let HirInstructionKind::Object {
         entries: complex_entries,
@@ -3863,7 +3756,6 @@ fn materializes_object_keys_entries_and_definition_order() {
             ..
         }
     ));
-
     assert_eq!(
         instruction("make('two')").semantics.evaluation,
         EvaluationMode::Eager
@@ -3886,7 +3778,6 @@ fn materializes_object_keys_entries_and_definition_order() {
             "the object node owns evaluation from its first computed key: {text}"
         );
     }
-
     let prototype = object_for_local("prototype");
     let HirInstructionKind::Object {
         entries: prototype_entries,
@@ -3916,7 +3807,6 @@ fn materializes_object_keys_entries_and_definition_order() {
             ..
         } if name == "safe"
     ));
-
     let shorthand_proto = object_for_local("shorthandProto");
     let HirInstructionKind::Object {
         entries: shorthand_proto_entries,
@@ -3934,7 +3824,6 @@ fn materializes_object_keys_entries_and_definition_order() {
             ..
         } if name == "__proto__"
     ));
-
     let numeric_keys = object_for_local("numericKeys");
     let HirInstructionKind::Object {
         entries: numeric_key_entries,
@@ -3956,7 +3845,6 @@ fn materializes_object_keys_entries_and_definition_order() {
         ));
     }
 }
-
 #[test]
 fn materializes_constructor_calls_and_spread_iteration_order() {
     let source = r#"
@@ -4030,7 +3918,6 @@ fn materializes_constructor_calls_and_spread_iteration_order() {
             .find(|instruction| instruction.result == Some(initializer))
             .unwrap_or_else(|| panic!("{name} constructor instruction"))
     };
-
     let empty = constructor_for_local("empty");
     let HirInstructionKind::New {
         callee: empty_callee,
@@ -4048,7 +3935,6 @@ fn materializes_constructor_calls_and_spread_iteration_order() {
         empty.semantics,
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
-
     let direct = constructor_for_local("direct");
     let HirInstructionKind::New {
         arguments: direct_arguments,
@@ -4082,7 +3968,6 @@ fn materializes_constructor_calls_and_spread_iteration_order() {
             EvaluationMode::Eager
         );
     }
-
     let spread = constructor_for_local("spread");
     let HirInstructionKind::New { callee, arguments } = &spread.kind else {
         panic!("typed spread constructor")
@@ -4128,7 +4013,6 @@ fn materializes_constructor_calls_and_spread_iteration_order() {
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
 }
-
 #[test]
 fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
     let source = r#"
@@ -4221,7 +4105,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
             .find(|instruction| instruction.result == Some(initializer))
             .unwrap_or_else(|| panic!("{name} call instruction"))
     };
-
     let direct = call_for_local("direct");
     let HirInstructionKind::Call(direct_call) = &direct.kind else {
         panic!("typed direct call")
@@ -4250,7 +4133,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
             EvaluationMode::Eager
         );
     }
-
     let spread = call_for_local("spread");
     let HirInstructionKind::Call(spread_call) = &spread.kind else {
         panic!("typed spread call")
@@ -4275,7 +4157,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
             "the call owns evaluation from its first spread: {text}"
         );
     }
-
     let optional = call_for_local("optional");
     let HirInstructionKind::Call(optional_call) = &optional.kind else {
         panic!("typed optional call")
@@ -4309,7 +4190,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
             EvaluationMode::Deferred
         );
     }
-
     for name in ["optionalMember", "continuedMember"] {
         let member = call_for_local(name);
         let HirInstructionKind::Call(member_call) = &member.kind else {
@@ -4353,7 +4233,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
             .evaluation,
         EvaluationMode::Deferred
     );
-
     let grouped = call_for_local("groupedMember");
     let HirInstructionKind::Call(grouped_call) = &grouped.kind else {
         panic!("typed grouped-member call")
@@ -4365,7 +4244,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
         EvaluationMode::Eager,
         "parentheses terminate the optional chain before the outer call"
     );
-
     let pure = call_for_local("pure");
     assert_eq!(pure.semantics.purity, Purity::Pure);
     assert_eq!(pure.semantics.mutation, MutationEffect::None);
@@ -4377,7 +4255,6 @@ fn preserves_call_spread_optional_and_pure_evaluation_boundaries() {
         EvaluationMode::Deferred
     );
 }
-
 #[test]
 fn preserves_exact_method_receivers_and_computed_keys_in_call_references() {
     let source = r#"
@@ -4460,7 +4337,6 @@ fn preserves_exact_method_receivers_and_computed_keys_in_call_references() {
         }));
         reference.clone()
     };
-
     let HirInstructionKind::Call(static_call) = &call_for_local("staticResult").kind else {
         panic!("static method call")
     };
@@ -4473,7 +4349,6 @@ fn preserves_exact_method_receivers_and_computed_keys_in_call_references() {
             optional: false,
         }] if name == "method"
     ));
-
     let HirInstructionKind::Call(computed_call) = &call_for_local("computedResult").kind else {
         panic!("computed method call")
     };
@@ -4501,7 +4376,6 @@ fn preserves_exact_method_receivers_and_computed_keys_in_call_references() {
         1,
         "a computed method key must be evaluated exactly once"
     );
-
     let HirInstructionKind::Call(temporary_call) = &call_for_local("temporaryResult").kind else {
         panic!("temporary-receiver method call")
     };
@@ -4524,12 +4398,10 @@ fn preserves_exact_method_receivers_and_computed_keys_in_call_references() {
         "a temporary method receiver must be evaluated exactly once"
     );
 }
-
 #[test]
 fn materializes_await_values_and_suspension_boundaries() {
     let source = r#"
         const top = await boot();
-
         async function run(load, consume, optional) {
             const direct = await load('direct');
             const nested = consume(await load('nested'));
@@ -4551,7 +4423,6 @@ fn materializes_await_values_and_suspension_boundaries() {
             .expect("authored await instruction");
         &source[span.start() as usize..span.end() as usize]
     };
-
     let module = &hir.functions[0];
     assert_eq!(module.kind, FunctionKind::Module);
     let module_instructions: Vec<_> = module
@@ -4576,7 +4447,6 @@ fn materializes_await_values_and_suspension_boundaries() {
             && authored(instruction) == "boot()"
             && matches!(instruction.kind, HirInstructionKind::Call(_))
     }));
-
     let run = hir
         .functions
         .iter()
@@ -4599,7 +4469,6 @@ fn materializes_await_values_and_suspension_boundaries() {
             .find(|instruction| authored(instruction) == text)
             .unwrap_or_else(|| panic!("instruction for {text}"))
     };
-
     for (await_text, input_text) in [
         ("await load('direct')", "load('direct')"),
         ("await load('nested')", "load('nested')"),
@@ -4617,7 +4486,6 @@ fn materializes_await_values_and_suspension_boundaries() {
         );
         assert!(await_instruction.semantics.may_throw);
     }
-
     for text in [
         "load('direct')",
         "await load('direct')",
@@ -4638,7 +4506,6 @@ fn materializes_await_values_and_suspension_boundaries() {
         );
     }
 }
-
 #[test]
 fn materializes_yield_values_delegation_and_lazy_arguments() {
     let source = r#"
@@ -4687,7 +4554,6 @@ fn materializes_yield_values_delegation_and_lazy_arguments() {
             .find(|instruction| authored(instruction) == text)
             .unwrap_or_else(|| panic!("instruction for {text}"))
     };
-
     let bare = instruction("yield");
     assert!(matches!(
         bare.kind,
@@ -4700,7 +4566,6 @@ fn materializes_yield_values_delegation_and_lazy_arguments() {
         bare.semantics,
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
-
     for (yield_text, input_text, delegate) in [
         ("yield make('value')", "make('value')", false),
         ("yield make('nested')", "make('nested')", false),
@@ -4724,7 +4589,6 @@ fn materializes_yield_values_delegation_and_lazy_arguments() {
         );
         assert!(yield_instruction.semantics.may_throw);
     }
-
     for text in [
         "make('value')",
         "yield make('value')",
@@ -4747,7 +4611,6 @@ fn materializes_yield_values_delegation_and_lazy_arguments() {
         );
     }
 }
-
 #[test]
 fn materializes_sequence_values_in_authored_evaluation_order() {
     let source = r#"
@@ -4812,7 +4675,6 @@ fn materializes_sequence_values_in_authored_evaluation_order() {
             })
             .unwrap_or_else(|| panic!("{name} initializer"))
     };
-
     let result_value = initializer("result");
     let result = instruction_for_result(result_value);
     let HirInstructionKind::Sequence { values } = &result.kind else {
@@ -4845,7 +4707,6 @@ fn materializes_sequence_values_in_authored_evaluation_order() {
                 .position(|instruction| instruction.result == Some(result_value))
                 .expect("sequence result position")
     );
-
     let assigned = local("assigned");
     let assigned_value = instructions
         .iter()
@@ -4868,7 +4729,6 @@ fn materializes_sequence_values_in_authored_evaluation_order() {
         "make('assigned')"
     );
     assert_eq!(authored(instruction_for_result(values[1])), "value");
-
     let deferred_value = initializer("deferred");
     let deferred_call = instruction_for_result(deferred_value);
     let HirInstructionKind::Call(call) = &deferred_call.kind else {
@@ -4892,7 +4752,6 @@ fn materializes_sequence_values_in_authored_evaluation_order() {
         EvaluationMode::Deferred
     );
 }
-
 #[test]
 fn materializes_template_quasis_coercions_and_lazy_ownership() {
     let source = r#"
@@ -4951,7 +4810,6 @@ fn materializes_template_quasis_coercions_and_lazy_ownership() {
             })
             .unwrap_or_else(|| panic!("{name} initializer"))
     };
-
     for (name, expected) in [("empty", ""), ("escaped", "line\n")] {
         let instruction = instruction_for_result(initializer(name));
         assert_eq!(
@@ -4963,7 +4821,6 @@ fn materializes_template_quasis_coercions_and_lazy_ownership() {
             fict_hir::InstructionSemantics::PURE_EAGER
         );
     }
-
     let dynamic = instruction_for_result(initializer("dynamic"));
     let HirInstructionKind::TemplateLiteral {
         quasis,
@@ -4990,7 +4847,6 @@ fn materializes_template_quasis_coercions_and_lazy_ownership() {
         dynamic.semantics,
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
-
     let lazy_call = instruction_for_result(initializer("lazy"));
     let HirInstructionKind::Call(call) = &lazy_call.kind else {
         panic!("typed optional template call")
@@ -5016,7 +4872,6 @@ fn materializes_template_quasis_coercions_and_lazy_ownership() {
         EvaluationMode::Deferred
     );
 }
-
 #[test]
 fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() {
     let source = r#"
@@ -5103,7 +4958,6 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
             *host,
         )
     };
-
     let (escaped, _, reference, quasis, substitutions, host) = tagged("escaped");
     assert!(reference.is_none());
     assert!(substitutions.is_empty());
@@ -5118,12 +4972,10 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
         escaped.semantics,
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
-
     let (_, _, _, quasis, substitutions, _) = tagged("invalid");
     assert!(substitutions.is_empty());
     assert_eq!(quasis[0].raw, r"\u{}");
     assert_eq!(quasis[0].cooked, None);
-
     let (_, _, _, quasis, substitutions, _) = tagged("surrogate");
     assert_eq!(substitutions.len(), 1);
     assert_eq!(quasis.len(), 2);
@@ -5133,7 +4985,6 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
         Some(JavaScriptString::from_code_units(vec![0xd800]))
     );
     assert_eq!(quasis[1].cooked, Some(JavaScriptString::default()));
-
     let (dynamic, tag, reference, quasis, substitutions, _) = tagged("dynamic");
     assert!(reference.is_none());
     assert_eq!(
@@ -5169,7 +5020,6 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
         matches!(instruction.kind, HirInstructionKind::SyntaxFragment { .. })
             && instruction.origin.primary_span == dynamic.origin.primary_span
     }));
-
     let (_, member_tag, member_reference, _, substitutions, host) = tagged("member");
     assert_eq!(substitutions.len(), 1);
     assert_eq!(host, fict_hir::CallHost::Unknown);
@@ -5189,7 +5039,6 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
                 HirInstructionKind::Read { place } if place == &member_reference
             )
     }));
-
     let (_, computed_tag, computed_reference, _, _, host) = tagged("computed");
     assert_eq!(host, fict_hir::CallHost::Unknown);
     let computed_reference = computed_reference.expect("computed tag reference");
@@ -5218,7 +5067,6 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
         1,
         "a computed tag key must be evaluated exactly once"
     );
-
     let (_, temporary_tag, temporary_reference, _, _, host) = tagged("temporary");
     assert_eq!(host, fict_hir::CallHost::Unknown);
     let temporary_reference = temporary_reference.expect("temporary tag reference");
@@ -5245,7 +5093,6 @@ fn materializes_tagged_template_objects_substitutions_and_utf16_cooked_values() 
         "a temporary tag receiver must be evaluated exactly once"
     );
 }
-
 #[test]
 fn materializes_dynamic_import_phases_options_and_coercion_order() {
     let source = r#"
@@ -5318,7 +5165,6 @@ fn materializes_dynamic_import_phases_options_and_coercion_order() {
         };
         (instruction, *specifier, *options, *phase)
     };
-
     let (simple, specifier, options, phase) = dynamic_import("simple");
     assert_eq!(phase, ImportPhase::Evaluation);
     assert!(options.is_none());
@@ -5327,7 +5173,6 @@ fn materializes_dynamic_import_phases_options_and_coercion_order() {
         simple.semantics,
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
-
     let (configured, specifier, options, phase) = dynamic_import("configured");
     let options = options.expect("configured import options");
     assert_eq!(phase, ImportPhase::Evaluation);
@@ -5356,10 +5201,8 @@ fn materializes_dynamic_import_phases_options_and_coercion_order() {
         matches!(instruction.kind, HirInstructionKind::SyntaxFragment { .. })
             && instruction.origin.primary_span == configured.origin.primary_span
     }));
-
     assert_eq!(dynamic_import("sourcePhase").3, ImportPhase::Source);
     assert_eq!(dynamic_import("deferPhase").3, ImportPhase::Defer);
-
     let lazy_call = instruction_for_result(initializer("lazy"));
     let HirInstructionKind::Call(call) = &lazy_call.kind else {
         panic!("typed optional call around import")
@@ -5380,7 +5223,6 @@ fn materializes_dynamic_import_phases_options_and_coercion_order() {
         EvaluationMode::Deferred
     );
 }
-
 #[test]
 fn materializes_static_computed_index_and_value_base_projections() {
     let source = r#"
@@ -5418,7 +5260,6 @@ fn materializes_static_computed_index_and_value_base_projections() {
         .iter()
         .find(|local| local.debug_name.as_deref() == Some("obj"))
         .expect("object parameter");
-
     let instructions: Vec<_> = project
         .blocks
         .iter()
@@ -5445,7 +5286,6 @@ fn materializes_static_computed_index_and_value_base_projections() {
     ));
     assert_eq!(deletion.semantics.mutation, MutationEffect::Observable);
     assert!(deletion.semantics.may_throw);
-
     let authored_projected_reads: Vec<_> = instructions
         .iter()
         .filter_map(|instruction| match &instruction.kind {
@@ -5534,7 +5374,6 @@ fn materializes_static_computed_index_and_value_base_projections() {
                 .is_some_and(|span| &source[span.start() as usize..span.end() as usize] == "make()")
             && matches!(instruction.kind, HirInstructionKind::Call(_))
     }));
-
     let projected_mutations: Vec<_> = instructions
         .iter()
         .filter(|instruction| {
@@ -5601,7 +5440,6 @@ fn materializes_static_computed_index_and_value_base_projections() {
         })
     }));
 }
-
 #[test]
 fn materializes_unresolved_host_places_without_lexical_ssa_or_target_reads() {
     let source = r#"
@@ -5684,7 +5522,6 @@ fn materializes_unresolved_host_places_without_lexical_ssa_or_target_reads() {
         instruction.semantics.mutation == MutationEffect::Observable
             && instruction.semantics.may_throw
     }));
-
     for mutation in &mutations[..3] {
         let place = match &mutation.kind {
             HirInstructionKind::Write { place, .. }
@@ -5711,7 +5548,6 @@ fn materializes_unresolved_host_places_without_lexical_ssa_or_target_reads() {
             ..
         }
     ));
-
     let static_write = match &mutations[3].kind {
         HirInstructionKind::Write { place, .. } => place,
         _ => panic!("static host write"),
@@ -5737,7 +5573,6 @@ fn materializes_unresolved_host_places_without_lexical_ssa_or_target_reads() {
             [fict_hir::Projection::ComputedProperty { optional: false, .. }]
         ) if *id == host_object
     ));
-
     let temporary_write = match &mutations[5].kind {
         HirInstructionKind::ReadWrite { place, .. } => place,
         _ => panic!("temporary update"),
@@ -5765,7 +5600,6 @@ fn materializes_unresolved_host_places_without_lexical_ssa_or_target_reads() {
         .position(|instruction| std::ptr::eq(*instruction, mutations[5]))
         .expect("temporary update position");
     assert!(call_position < update_position);
-
     let host_reads: Vec<_> = instructions
         .iter()
         .copied()
@@ -5795,7 +5629,6 @@ fn materializes_unresolved_host_places_without_lexical_ssa_or_target_reads() {
             )
     ));
 }
-
 #[test]
 fn materializes_bare_host_reads_without_breaking_special_or_dynamic_references() {
     let source = r#"
@@ -5919,7 +5752,6 @@ fn materializes_bare_host_reads_without_breaking_special_or_dynamic_references()
                     && place.projections.is_empty()
         )
     }));
-
     let result_for_authored = |text: &str| {
         instructions
             .iter()
@@ -5961,7 +5793,6 @@ fn materializes_bare_host_reads_without_breaking_special_or_dynamic_references()
             .iter()
             .any(|global| global.name == "missingTypeof" || global.name == "missingDelete")
     );
-
     let shadow = function("shadow");
     assert!(
         shadow
@@ -5974,7 +5805,6 @@ fn materializes_bare_host_reads_without_breaking_special_or_dynamic_references()
             })
             .all(|place| matches!(place.base, fict_hir::PlaceBase::Local(_)))
     );
-
     let dynamic = function("dynamic");
     assert!(
         dynamic
@@ -6014,7 +5844,6 @@ fn materializes_bare_host_reads_without_breaking_special_or_dynamic_references()
         assert!(!hir.globals.iter().any(|global| global.name == name));
     }
 }
-
 #[test]
 fn materializes_reference_aware_delete_targets_without_property_reads() {
     let source = r#"
@@ -6090,7 +5919,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
         .iter()
         .find(|local| local.debug_name.as_deref() == Some("obj"))
         .expect("obj parameter");
-
     for (name, property, optional) in [
         ("staticResult", "fixed", false),
         ("parenthesizedResult", "nested", false),
@@ -6113,7 +5941,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
         assert_eq!(deletion.semantics.mutation, MutationEffect::Observable);
         assert!(deletion.semantics.may_throw);
     }
-
     let computed = root("computedResult");
     let HirInstructionKind::Delete {
         target: DeleteTarget::Place(computed_place),
@@ -6145,7 +5972,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
             .expect("instruction position")
     };
     assert!(position(key_call) < position(computed));
-
     for (name, operand) in [("valueResult", "effect()"), ("literalResult", "1")] {
         let deletion = root(name);
         let HirInstructionKind::Delete {
@@ -6164,7 +5990,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
         );
         assert!(position(operand_instruction) < position(deletion));
     }
-
     let local_parameter = function
         .locals
         .iter()
@@ -6190,7 +6015,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
                     && place.projections.is_empty()
         )
     }));
-
     let global_delete = root("globalResult");
     assert!(matches!(
         &global_delete.kind,
@@ -6202,7 +6026,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
         global_delete.semantics,
         fict_hir::InstructionSemantics::CONSERVATIVE_EAGER
     );
-
     for member in ["obj.fixed", "obj[key()]", "obj.nested", "obj?.optional"] {
         assert!(
             !instructions.iter().any(|instruction| {
@@ -6238,7 +6061,6 @@ fn materializes_reference_aware_delete_targets_without_property_reads() {
         );
     }
 }
-
 #[test]
 fn classifies_nested_state_mutation_by_strict_guarantee_policy() {
     let source = r#"
@@ -6268,7 +6090,6 @@ fn classifies_nested_state_mutation_by_strict_guarantee_policy() {
         finding.guarantee_class,
         fict_diagnostics::GuaranteeClass::Fallback
     );
-
     let fallback = build_hir(
         source,
         options(OxcSourceLanguage::JavaScript),
@@ -6288,7 +6109,6 @@ fn classifies_nested_state_mutation_by_strict_guarantee_policy() {
         fict_diagnostics::DiagnosticSeverity::Warning
     );
 }
-
 #[test]
 fn classifies_nested_state_deletion_by_strict_guarantee_policy() {
     let source = r#"
@@ -6318,7 +6138,6 @@ fn classifies_nested_state_deletion_by_strict_guarantee_policy() {
         finding.guarantee_class,
         fict_diagnostics::GuaranteeClass::Fallback
     );
-
     let fallback = build_hir(
         source,
         options(OxcSourceLanguage::JavaScript),
@@ -6352,7 +6171,6 @@ fn classifies_nested_state_deletion_by_strict_guarantee_policy() {
             })
     }));
 }
-
 #[test]
 fn classifies_hooks_and_binding_resolved_reactive_callbacks() {
     let source = r#"
@@ -6390,7 +6208,6 @@ fn classifies_hooks_and_binding_resolved_reactive_callbacks() {
         .expect("render call");
     assert!(matches!(render_call.host, CallHost::ReactiveScope(_)));
 }
-
 #[test]
 fn retains_patterns_and_function_bodies_as_owned_controlled_fragments() {
     let source = "const View = ({ value = 1, ...rest }) => value + rest.offset;";
@@ -6419,7 +6236,6 @@ fn retains_patterns_and_function_bodies_as_owned_controlled_fragments() {
         .expect("adapter fragment");
     assert!(adapter.source.contains("value = 1"));
 }
-
 #[test]
 fn unsupported_macro_shapes_fail_closed_with_structured_codes() {
     let cases = [
@@ -6446,7 +6262,6 @@ fn unsupported_macro_shapes_fail_closed_with_structured_codes() {
         assert_eq!(output.diagnostics[0].code.as_str(), code);
     }
 }
-
 #[test]
 fn applies_function_directives_and_erases_type_only_binding_ids() {
     let source = r#"
@@ -6480,7 +6295,6 @@ fn applies_function_directives_and_erases_type_only_binding_ids() {
         assert_eq!(binding.id.as_usize(), index);
     }
 }
-
 #[test]
 fn builds_structural_jsx_tags_attributes_children_and_spreads() {
     let source = r#"
@@ -6538,7 +6352,6 @@ fn builds_structural_jsx_tags_attributes_children_and_spreads() {
             .any(|child| matches!(child, fict_hir::JsxChild::Spread { .. }))
     );
 }
-
 #[test]
 fn models_binding_aware_direct_keyed_map_callbacks() {
     let source = r#"
@@ -6582,7 +6395,6 @@ fn models_binding_aware_direct_keyed_map_callbacks() {
         .and_then(|key| key.primary_span)
         .expect("source key span");
     assert_eq!(&source[key.start() as usize..key.end() as usize], "row.id");
-
     let mutated = build_hir(
         "export function App(rows) { return <ul>{rows.map(row => <li key={row.id}>{row++}</li>)}</ul>; }",
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -6598,7 +6410,6 @@ fn models_binding_aware_direct_keyed_map_callbacks() {
         fict_hir::JsxChild::Expression { list: None, .. }
     ));
 }
-
 #[test]
 fn models_direct_unkeyed_map_callbacks_with_index_identity() {
     let source = r#"
@@ -6630,7 +6441,6 @@ fn models_direct_unkeyed_map_callbacks_with_index_identity() {
     assert_eq!(list.item_references.len(), 1);
     assert_eq!(list.index_references.len(), 1);
     assert!(list.needs_index);
-
     let spread = build_hir(
         "import { $state } from 'fict'; export function App() { let rows = $state([{ name: 'A' }]); return <ul>{rows.map(row => <li {...row}>{row.name}</li>)}</ul>; }",
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -6656,7 +6466,6 @@ fn models_direct_unkeyed_map_callbacks_with_index_identity() {
         fict_hir::JsxChild::Expression { list: None, .. }
     ));
 }
-
 #[test]
 fn traces_trusted_array_method_chains_to_their_base_receiver() {
     let source = r#"
@@ -6697,7 +6506,6 @@ fn traces_trusted_array_method_chains_to_their_base_receiver() {
         "rows.filter(row => row.visible)"
     );
 }
-
 #[test]
 fn distinguishes_optional_map_members_from_optional_calls() {
     let source = r#"
@@ -6724,7 +6532,6 @@ fn distinguishes_optional_map_members_from_optional_calls() {
         panic!("optional map metadata")
     };
     assert!(list.optional);
-
     let optional_call = build_hir(
         "import { $state } from 'fict'; export function App() { let rows = $state([{ id: 1 }]); return <ul>{rows.map?.(row => <li key={row.id}>{row.id}</li>)}</ul>; }",
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -6744,7 +6551,6 @@ fn distinguishes_optional_map_members_from_optional_calls() {
         fict_hir::JsxChild::Expression { list: None, .. }
     ));
 }
-
 #[test]
 fn models_context_free_anonymous_function_map_callbacks() {
     let source = r#"
@@ -6773,7 +6579,6 @@ fn models_context_free_anonymous_function_map_callbacks() {
     assert!(!hir.functions[list.callback.as_usize()].flags.is_arrow);
     assert_eq!(list.item_references.len(), 1);
     assert_eq!(list.index_references.len(), 1);
-
     for callback in [
         "function (row) { return <li key={row.id}>{this.label}</li>; }",
         "function (row) { return <li key={row.id}>{arguments.length}</li>; }",
@@ -6802,7 +6607,6 @@ fn models_context_free_anonymous_function_map_callbacks() {
         ));
     }
 }
-
 #[test]
 fn models_simple_component_object_props_with_exact_read_origins() {
     let source = r#"
@@ -6985,7 +6789,6 @@ fn models_simple_component_object_props_with_exact_read_origins() {
         fict_hir::HirObjectParameterMode::Mutable
     );
     assert!(mutated_properties[4].references.is_empty());
-
     let callable = build_hir(
         "function Button({ onClick }) { const invoke = onClick; return <button onClick={() => invoke.call(null)}>go</button>; } function Mixed({ label }) { label(); return <span>{String(label)}</span>; } export function App(fn) { return <><Button onClick={fn} /><Mixed label={fn} /></>; }",
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -7035,7 +6838,6 @@ fn models_simple_component_object_props_with_exact_read_origins() {
     );
     assert_eq!(mixed_property.references.len(), 2);
 }
-
 #[test]
 fn diagnoses_unsupported_component_props_patterns_with_strict_fallback_policy() {
     let source = r#"
@@ -7099,7 +6901,6 @@ fn diagnoses_unsupported_component_props_patterns_with_strict_fallback_policy() 
             "...userRest"
         ]
     );
-
     let fallback = build_hir(
         source,
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -7136,7 +6937,6 @@ fn diagnoses_unsupported_component_props_patterns_with_strict_fallback_policy() 
         assert!(function.parameters[0].object_properties.is_none());
     }
 }
-
 #[test]
 fn assigns_dense_function_local_storage_and_outer_captures_without_name_identity() {
     let source = r#"
@@ -7165,7 +6965,6 @@ fn assigns_dense_function_local_storage_and_outer_captures_without_name_identity
         .collect();
     assert_eq!(value_bindings.len(), 2);
     assert_ne!(value_bindings[0], value_bindings[1]);
-
     let app = hir
         .functions
         .iter()
@@ -7198,7 +6997,6 @@ fn assigns_dense_function_local_storage_and_outer_captures_without_name_identity
             .all(|local| local.kind != fict_hir::LocalKind::Capture)
     );
 }
-
 #[test]
 fn enforces_state_owner_target_and_top_level_placement() {
     let cases = [
@@ -7247,7 +7045,6 @@ fn enforces_state_owner_target_and_top_level_placement() {
             output.diagnostics
         );
     }
-
     for source in [
         "import { $state } from 'fict'; function App() { const value = $state(0); return value; }",
         "import { $state } from 'fict'; function useValue() { const value = $state(0); return value; }",
@@ -7261,7 +7058,6 @@ fn enforces_state_owner_target_and_top_level_placement() {
         assert!(output.hir.is_some());
     }
 }
-
 #[test]
 fn enforces_effect_and_memo_control_flow_placement() {
     let cases = [
@@ -7298,7 +7094,6 @@ fn enforces_effect_and_memo_control_flow_placement() {
             output.diagnostics
         );
     }
-
     for source in [
         "import { $effect } from 'fict'; $effect(() => {});",
         "import { $memo } from 'fict'; { $memo(() => value); }",
@@ -7312,7 +7107,6 @@ fn enforces_effect_and_memo_control_flow_placement() {
         assert!(output.hir.is_some());
     }
 }
-
 #[test]
 fn configured_reactive_scope_is_a_binding_resolved_state_owner() {
     let source = r#"
@@ -7334,7 +7128,6 @@ fn configured_reactive_scope_is_a_binding_resolved_state_owner() {
     assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
     assert!(output.hir.is_some());
 }
-
 #[test]
 fn enforces_direct_hook_owner_and_control_flow_placement_by_binding() {
     let cases = [
@@ -7369,7 +7162,6 @@ fn enforces_direct_hook_owner_and_control_flow_placement_by_binding() {
                 .any(|diagnostic| diagnostic.code.as_str() == expected)
         );
     }
-
     for source in [
         "import { useCounter } from './hooks'; function App() { useCounter(); return null; }",
         "function helper(useCounter) { return useCounter(); }",
@@ -7387,13 +7179,11 @@ fn enforces_direct_hook_owner_and_control_flow_placement_by_binding() {
         );
     }
 }
-
 #[test]
 fn enforces_binding_aware_selector_control_flow_placement() {
     let source = r#"
         import { createSelector as select } from 'fict';
         import * as Advanced from 'fict/advanced';
-
         function Demo({ ready, items, value }) {
             if (ready) select(() => value);
             for (const item of items) Advanced.createSelector(() => item);
@@ -7402,7 +7192,6 @@ fn enforces_binding_aware_selector_control_flow_placement() {
             select(() => value) && ready;
             return <div>{ready && select(() => value)(value)}</div>;
         }
-
         function Nested({ ready, value }) {
             if (ready) {
                 const setup = () => select(() => value);
@@ -7410,12 +7199,10 @@ fn enforces_binding_aware_selector_control_flow_placement() {
             }
             return <div />;
         }
-
         function Immediate({ ready, value }) {
             if (ready) (() => select(() => value))();
             return <div />;
         }
-
         function Shadow({ ready, value }, select) {
             if (ready) select(() => value);
             return <div />;
@@ -7454,7 +7241,6 @@ fn enforces_binding_aware_selector_control_flow_placement() {
             "select(() => value)"
         ]
     );
-
     let fallback = build_hir(
         source,
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -7477,7 +7263,6 @@ fn enforces_binding_aware_selector_control_flow_placement() {
         diagnostic.severity == fict_diagnostics::DiagnosticSeverity::Warning
     }));
 }
-
 #[test]
 fn enforces_namespace_and_member_hook_placement() {
     let cases = [
@@ -7508,7 +7293,6 @@ fn enforces_namespace_and_member_hook_placement() {
                 .any(|diagnostic| diagnostic.code.as_str() == expected)
         );
     }
-
     for source in [
         "import * as hooks from './hooks'; function App() { hooks.useCounter?.(); return null; }",
         "const api = { useCounter() {} }; api.useCounter();",
@@ -7525,12 +7309,10 @@ fn enforces_namespace_and_member_hook_placement() {
         );
     }
 }
-
 #[test]
 fn diagnoses_binding_aware_reactive_writes_in_jsx_children() {
     let source = r#"
         import { $state, $store } from 'fict';
-
         function App(values) {
             let count = $state(0);
             let alias = count;
@@ -7589,7 +7371,6 @@ fn diagnoses_binding_aware_reactive_writes_in_jsx_children() {
             "{count++}"
         ]
     );
-
     let fallback = build_hir(
         source,
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -7617,7 +7398,6 @@ fn diagnoses_binding_aware_reactive_writes_in_jsx_children() {
             })
     );
 }
-
 #[test]
 fn diagnoses_only_intrinsic_jsx_spreads_once_per_element() {
     let source = r#"
@@ -7657,7 +7437,6 @@ fn diagnoses_only_intrinsic_jsx_spreads_once_per_element() {
         })
         .collect::<Vec<_>>();
     assert_eq!(finding_sources, ["{...domProps}", "{...svgProps}"]);
-
     let fallback = build_hir(
         source,
         options(OxcSourceLanguage::JavaScriptJsx),
@@ -7676,7 +7455,6 @@ fn diagnoses_only_intrinsic_jsx_spreads_once_per_element() {
         2
     );
 }
-
 #[test]
 fn diagnoses_shallow_inline_non_event_jsx_function_props() {
     let source = r#"
@@ -7731,7 +7509,6 @@ fn diagnoses_shallow_inline_non_event_jsx_function_props() {
         ]
     );
 }
-
 #[test]
 fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing() {
     let source = r#"
@@ -7783,7 +7560,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
     };
     let fragment_kind =
         |fragment: fict_hir::SyntaxFragmentId| hir.syntax_fragments[fragment.as_usize()].kind;
-
     let class_instructions: Vec<_> = instructions
         .iter()
         .copied()
@@ -7806,7 +7582,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
         .copied()
         .find(|instruction| !authored(instruction).contains("class Example"))
         .expect("class expression fragment");
-
     let decorator_instructions: Vec<_> = instructions
         .iter()
         .copied()
@@ -7829,7 +7604,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
             .iter()
             .any(|instruction| authored(instruction).contains("decorate('field')"))
     );
-
     let HirInstructionKind::SyntaxFragment {
         fragment: declaration_fragment,
         inputs: declaration_inputs,
@@ -7865,7 +7639,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
     for decorator in &decorator_instructions {
         assert!(declaration_inputs.contains(&decorator.result.expect("decorator value")));
     }
-
     let summary_names = |fragment: fict_hir::SyntaxFragmentId| {
         hir.syntax_fragments[fragment.as_usize()]
             .summary
@@ -7885,7 +7658,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
     assert!(expression_references.contains(&"base"));
     assert!(expression_references.contains(&"staticValue"));
     assert!(!expression_references.contains(&"instanceValue"));
-
     let local = |name: &str| {
         function
             .locals
@@ -7915,7 +7687,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
                 && initializer == expression_class.result.expect("class expression value")
         )
     }));
-
     let calls = |source_text: &str| {
         instructions
             .iter()
@@ -7949,7 +7720,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
         assert!(!declaration_inputs.contains(&value));
         assert!(!expression_inputs.contains(&value));
     }
-
     for class in &class_instructions {
         assert!(!instructions.iter().any(|instruction| {
             instruction.origin.primary_span == class.origin.primary_span
@@ -7961,7 +7731,6 @@ fn retains_classes_and_decorators_with_exact_definition_and_initializer_timing()
         }));
     }
 }
-
 fn memo_side_effect_diagnostics(source: &str) -> Vec<fict_diagnostics::Diagnostic> {
     build_hir(
         source,
@@ -7976,7 +7745,6 @@ fn memo_side_effect_diagnostics(source: &str) -> Vec<fict_diagnostics::Diagnosti
     .filter(|diagnostic| diagnostic.code.as_str() == "FICT-M003")
     .collect()
 }
-
 #[test]
 fn diagnoses_eager_memo_side_effect_evaluation_shapes() {
     let callbacks = [
@@ -8030,7 +7798,6 @@ fn diagnoses_eager_memo_side_effect_evaluation_shapes() {
         "((() => fetch('/api')) as unknown)",
         "(() => fetch('/api')) satisfies (() => unknown)",
     ];
-
     for callback in callbacks {
         let source =
             format!("import {{ $memo }} from 'fict'; const value = $memo({callback}); void value;");
@@ -8054,7 +7821,6 @@ fn diagnoses_eager_memo_side_effect_evaluation_shapes() {
         );
     }
 }
-
 #[test]
 fn accepts_pure_and_lazy_memo_evaluation_shapes() {
     let callbacks = [
@@ -8080,18 +7846,15 @@ fn accepts_pure_and_lazy_memo_evaluation_shapes() {
         "() => (() => 1)()",
         "() => wrap(1)",
     ];
-
     for callback in callbacks {
         let source =
             format!("import {{ $memo }} from 'fict'; const value = $memo({callback}); void value;");
         let diagnostics = memo_side_effect_diagnostics(&source);
         assert!(diagnostics.is_empty(), "{callback}: {diagnostics:?}");
     }
-
     let non_tail = "import { $memo } from 'fict'; const stable = () => 1; const value = $memo((() => fetch('/api'), stable));";
     assert!(memo_side_effect_diagnostics(non_tail).is_empty());
 }
-
 #[test]
 fn resolves_memo_and_safe_global_bindings_before_side_effect_diagnostics() {
     let source = r#"

--- a/crates/fict-compiler/src/pipeline.rs
+++ b/crates/fict-compiler/src/pipeline.rs
@@ -1,16 +1,3 @@
-use std::mem;
-
-use fict_compiler_oxc::{
-    HirBuildOptions, OxcCompileOptions, OxcModuleKind, OxcSourceLanguage, OxcTypeScriptOptions,
-    build_hir, emit_program,
-};
-use fict_diagnostics::{
-    Diagnostic, DiagnosticBundle, DiagnosticCode, DiagnosticSeverity, GuaranteeClass,
-};
-use fict_emit::{NoJsxLoweringOptions, RuntimeFamily, lower_core};
-use fict_hir::{FictMacroKind, HirFile, HirInstructionKind, StructuredSourceKind};
-use fict_metadata::MetadataResolutionStatus;
-
 use crate::control_flow_diagnostics::reactive_control_flow_diagnostics;
 use crate::diagnostic_policy::{apply_diagnostic_policy, configured_diagnostic_severity};
 use crate::metadata_analysis::generate_module_metadata;
@@ -21,7 +8,17 @@ use crate::{
     HandlerArtifactMetadata, ModuleKind, NormalizedCompileRequest, RawSourceMap, SourceLanguage,
     run_core_passes,
 };
-
+use fict_compiler_oxc::{
+    HirBuildOptions, OxcCompileOptions, OxcModuleKind, OxcSourceLanguage, OxcTypeScriptOptions,
+    build_hir, emit_program,
+};
+use fict_diagnostics::{
+    Diagnostic, DiagnosticBundle, DiagnosticCode, DiagnosticSeverity, GuaranteeClass,
+};
+use fict_emit::{NoJsxLoweringOptions, RuntimeFamily, lower_core};
+use fict_hir::{FictMacroKind, HirFile, HirInstructionKind, StructuredSourceKind};
+use fict_metadata::MetadataResolutionStatus;
+use std::mem;
 /// Execute the currently connected native pipeline and return a complete result.
 #[must_use]
 pub fn compile(request: CompileRequest) -> CompileResult {
@@ -30,7 +27,6 @@ pub fn compile(request: CompileRequest) -> CompileResult {
         Err(error) => invalid_request_result(error.to_string()),
     }
 }
-
 /// Construct a structured result for malformed public input.
 #[must_use]
 pub fn invalid_request_result(message: impl Into<String>) -> CompileResult {
@@ -41,7 +37,6 @@ pub fn invalid_request_result(message: impl Into<String>) -> CompileResult {
         Some("fix the request shape before invoking the native compiler"),
     )
 }
-
 /// Construct the generic result returned when the N-API panic boundary fires.
 #[must_use]
 pub fn internal_error_result() -> CompileResult {
@@ -52,11 +47,9 @@ pub fn internal_error_result() -> CompileResult {
         Some("retry with the legacy backend for the entire build and report the failing fixture"),
     )
 }
-
 fn compile_normalized(request: NormalizedCompileRequest) -> CompileResult {
     let mut result = CompileResult::empty();
     result.diagnostics = request.integration_diagnostics.clone();
-
     #[cfg(not(feature = "preview"))]
     if request
         .options
@@ -2011,7 +2004,7 @@ mod tests {
                 .code
                 .contains("const __fictCtx_1 = __fictUseContext()")
         );
-        assert!(state.code.contains("__fictUseSignal(__fictCtx_1, 0)"));
+        assert!(state.code.contains("name: \"count\""), "{}", state.code);
         assert!(state.code.contains("count(__fict_value)"));
         assert!(state.code.contains("count(__fict_previous + 1)"));
         assert!(state.code.contains("count(),"), "{}", state.code);
@@ -3504,7 +3497,23 @@ mod tests {
                 .iter()
                 .all(|diagnostic| diagnostic.code.as_str() != "FICT-R006")
         );
-        assert!(result.code.contains("if (count() > 10)"), "{}", result.code);
+        assert!(
+            result.code.contains("createConditional(() => count() > 10"),
+            "{}",
+            result.code
+        );
+        let prop_ternary = compile(request(
+            "export function App(props) { return props.broken ? <Broken /> : <Ready />; }",
+            "prop-ternary-return.tsx",
+        ));
+        assert!(!prop_ternary.has_errors(), "{:?}", prop_ternary.diagnostics);
+        assert!(
+            prop_ternary
+                .code
+                .contains("createConditional(() => props.broken"),
+            "{}",
+            prop_ternary.code
+        );
 
         let non_jsx = compile(request(
             "import { $state } from 'fict'; export function App() { const count = $state(0); if (count > 10 && maybe()) return count; return 0; }",
@@ -4014,7 +4023,7 @@ mod tests {
     #[test]
     fn emits_fine_grained_ternary_and_logical_conditions() {
         let result = compile(request(
-            "import { $state } from 'fict'; const Yes = () => null; const No = () => null; export function App() { let show = $state(true); return <main>{show ? <><Yes /></> : <No />}{show && <span>{show}</span>}</main>; }",
+            "import { $state } from 'fict'; const Yes = () => null; const No = () => null; export function App() { let show = $state(true); let count = $state(0); return <main>{show ? <><Yes /></> : <No />}{show && <span>{count}</span>}</main>; }",
             "conditional.tsx",
         ));
 
@@ -4037,6 +4046,11 @@ mod tests {
         assert!(result.code.contains("type: Yes"), "{}", result.code);
         assert!(result.code.contains("type: No"), "{}", result.code);
         assert!(result.code.contains("void 0"), "{}", result.code);
+        assert!(
+            result.code.contains("trackBranchReads: true"),
+            "{}",
+            result.code
+        );
         assert!(
             result.code.matches("onDestroy(").count() >= 2,
             "{}",

--- a/crates/fict-compiler/src/pipeline.rs
+++ b/crates/fict-compiler/src/pipeline.rs
@@ -4889,6 +4889,30 @@ mod tests {
 
     #[cfg(feature = "preview")]
     #[test]
+    fn transforms_preview_handlers_with_source_spans_beyond_the_artifact_wrapper() {
+        let source = format!(
+            "/* {} */\nexport function App() {{ return <button onClick$={{(event: MouseEvent) => event.preventDefault()}}>Deploy</button>; }}",
+            "padding".repeat(512)
+        );
+        let mut input = request(&source, "preview-long-handler-offset.tsx");
+        input.options.sourcemap = true;
+        input.options.preview = Some(CompilerPreviewOptions {
+            resumable: true,
+            auto_extract_handlers: false,
+            ..CompilerPreviewOptions::default()
+        });
+
+        let result = compile(input);
+
+        assert!(!result.has_errors(), "{:?}", result.diagnostics);
+        let artifact = result.artifacts.first().expect("one handler artifact");
+        assert!(artifact.code.contains("event.preventDefault()"));
+        assert!(!artifact.code.contains("MouseEvent"));
+        assert!(artifact.map.is_some());
+    }
+
+    #[cfg(feature = "preview")]
+    #[test]
     fn scopes_preview_prevent_default_detection_to_the_event_parameter() {
         let source = r#"
             export function App() {

--- a/crates/fict-compiler/src/pipeline.rs
+++ b/crates/fict-compiler/src/pipeline.rs
@@ -228,6 +228,11 @@ fn compile_normalized(request: NormalizedCompileRequest) -> CompileResult {
         .iter()
         .map(|analysis| analysis.cycles.clone())
         .collect();
+    let scopes: Vec<_> = core
+        .functions
+        .iter()
+        .map(|analysis| analysis.scopes.clone())
+        .collect();
     let runtime_family = if frontend
         .macro_imports
         .iter()
@@ -241,6 +246,7 @@ fn compile_normalized(request: NormalizedCompileRequest) -> CompileResult {
         &core.hir,
         &regions,
         &cycles,
+        Some(&scopes),
         NoJsxLoweringOptions {
             runtime_family,
             strict_guarantee: request.options.strict_guarantee,
@@ -698,6 +704,26 @@ mod tests {
         );
         assert!(!result.code.contains("import {"), "{}", result.code);
         assert!(!result.code.contains("export default"), "{}", result.code);
+    }
+
+    #[test]
+    fn lowers_derived_values_and_preserves_fragment_roots() {
+        #[rustfmt::skip]
+        let cases = [
+            ("import { $effect, $state } from 'fict'; export function Counter() { let count = $state(2); const doubled = count * 2; $effect(() => doubled); return <div>{doubled}</div>; }", "__fictUseMemo(__fictCtx, () => count() * 2)|() => doubled()|__fictUseEffect(__fictCtx, () => doubled())", ""),
+            ("import { $effect, $state } from 'fict'; export function Counter() { 'use no memo'; let count = $state(2); const doubled = count * 2; $effect(() => doubled); return <div>{doubled}</div>; }", "() => count() * 2|() => doubled()|__fictUseEffect(__fictCtx, () => doubled())", ""),
+            ("export function Label(props) { const text = props.value + '!'; return <span>{text}</span>; }", "__fictUseMemo(__fictCtx, () => props.value + \"!\")|() => text()", ""),
+            ("import { createEffect } from '@fictjs/runtime'; export function Routes(props) { const routes = props.routes ?? []; const compiled = routes.map(value => value); const branches = compiled.slice(); const match = branches.slice(0, 1)[0]; const route = match.route; const hasPreload = typeof route.preload === 'function'; createEffect(() => { for (const branch of branches) void branch; void hasPreload; }); return route; }", "() => match().route|const branch of branches()", "__fictUseMemo()("),
+            ("import { reactive } from '@fictjs/runtime'; export function App() { const render = () => null; return <>{[reactive(render)]}</>; }", "template(\"<!---->\", void 0, void 0, void 0, true)|insert(__fict_jsx", ""),
+        ];
+        for (source, expected, rejected) in cases {
+            let result = compile(request(source, "lowering.tsx"));
+            assert!(!result.has_errors(), "{:?}", result.diagnostics);
+            #[rustfmt::skip]
+            assert!(expected.split('|').all(|s| result.code.contains(s)), "{}", result.code);
+            #[rustfmt::skip]
+            assert!(rejected.is_empty() || rejected.split('|').all(|s| !result.code.contains(s)), "{}", result.code);
+        }
     }
 
     #[test]
@@ -2078,11 +2104,8 @@ mod tests {
             "{}",
             result.code
         );
-        assert!(
-            result.code.contains("template(\"<i>a</i><i>b</i>\")"),
-            "{}",
-            result.code
-        );
+        let fragment = "template(\"<i>a</i><i>b</i>\", void 0, void 0, void 0, true)";
+        assert!(result.code.contains(fragment), "{}", result.code);
         assert!(!result.code.contains("return <"), "{}", result.code);
     }
 
@@ -2392,22 +2415,23 @@ mod tests {
 
     #[test]
     fn emits_reactive_component_prop_getters() {
-        let result = compile(request(
-            "import { $state } from 'fict'; const Card = (_props) => null; export function App() { let count = $state(0); return <Card value={count} />; }",
+        let mut input = request(
+            "import { $state } from 'fict'; const Card = (_props) => null; const handler = makeHandler(); export function App() { let count = $state(0); return <Card value={count} onSelect={handler} />; } export function Router(props) { const owns = !props.history; const history = props.history || makeHistory(); if (owns) history.destroy?.(); return <Card history={history} />; }",
             "reactive-component.tsx",
-        ));
+        );
+        input.options.strict_guarantee = false;
+        let result = compile(input);
 
         assert!(!result.has_errors(), "{:?}", result.diagnostics);
-        assert!(
-            result.code.contains("import { __fictProp"),
-            "{}",
-            result.code
-        );
-        assert!(
-            result.code.contains("value: __fictProp(() => count())"),
-            "{}",
-            result.code
-        );
+        for snippet in [
+            "import { __fictProp",
+            "value: __fictProp(() => count())",
+            "onSelect: handler",
+            "history: __fictProp(() => history())",
+        ] {
+            assert!(result.code.contains(snippet), "{}", result.code);
+        }
+        assert!(!result.code.contains("() => handler"), "{}", result.code);
     }
 
     #[test]
@@ -2579,11 +2603,7 @@ mod tests {
         assert!(result.code.contains("type: Row"), "{}", result.code);
         assert!(result.code.contains("() => row()"), "{}", result.code);
         assert!(result.code.contains("key: __fict_key_"), "{}", result.code);
-        assert!(
-            result.code.contains("label: __fictProp(() => __fict_key)"),
-            "{}",
-            result.code
-        );
+        assert!(result.code.contains("label: __fict_key"), "{}", result.code);
     }
 
     #[test]
@@ -3639,7 +3659,7 @@ mod tests {
 
     #[test]
     fn emits_authored_try_catch_finally_from_structured_hir() {
-        let source = "import { $state } from 'fict'; export function App(shouldThrow) { let result = $state('init'); try { result = 'try'; if (shouldThrow) throw new Error('boom'); } catch (error) { result = error.message; } finally { result += '!'; } return <span>{result}</span>; }";
+        let source = "import { $state } from 'fict'; export function App() { let result = $state('init'); try { result = 'try'; if (globalThis.shouldThrow) throw new Error('boom'); } catch (error) { result = error.message; } finally { result += '!'; } return <span>{result}</span>; }";
         let compiled = compile(request(source, "try-catch-finally.tsx"));
 
         assert!(!compiled.has_errors(), "{:?}", compiled.diagnostics);

--- a/crates/fict-compiler/tests/analysis_parity.rs
+++ b/crates/fict-compiler/tests/analysis_parity.rs
@@ -146,6 +146,11 @@ fn normalize_reactive_bindings(
     analysis: &FunctionPassAnalysis,
     user_names: &BTreeSet<String>,
 ) -> Vec<ReactiveBindingSnapshot> {
+    #[rustfmt::skip]
+    let has_root = analysis.scopes.bindings.iter().any(|binding| reactive_kind_priority(binding.kind) == 3);
+    if !has_root {
+        return Vec::new();
+    }
     let mut grouped: BTreeMap<String, (ReactiveBindingKind, BTreeSet<String>)> = BTreeMap::new();
     for binding in &analysis.scopes.bindings {
         let Some(name) = local_name(function, binding.name.local) else {

--- a/crates/fict-compiler/tests/pass_manager.rs
+++ b/crates/fict-compiler/tests/pass_manager.rs
@@ -366,10 +366,10 @@ fn propagates_structured_imported_hook_members_into_scopes_and_regions() {
     let frontend = build_hir(
         r#"
             import { useCounter } from './hooks';
-            export function App(key) {
+            export function App() {
                 const api = useCounter();
                 const derived = api.count === 1;
-                const dynamic = api[key] === 1;
+                const dynamic = api[globalThis.key] === 1;
                 const reader = () => {
                     const nestedDerived = api.count === 2;
                     return nestedDerived;

--- a/crates/fict-compiler/tests/source_map_probes.rs
+++ b/crates/fict-compiler/tests/source_map_probes.rs
@@ -127,7 +127,7 @@ fn maps_reactivity_props_events_and_control_flow_origins() {
     );
     let output = MappedOutput::compile(source, "origins.tsx");
 
-    output.assert_maps("__fictUseSignal(__fictCtx, 0)", 0, "$state", 1);
+    output.assert_maps("__fictUseSignal(__fictCtx, 0,", 0, "$state", 1);
     output.assert_maps("document.title", 0, "document.title", 0);
     output.assert_maps("const value = prop", 0, "value", 0);
     output.assert_maps("String(value())", 0, "String(value)", 0);

--- a/crates/fict-emit/src/conditional_return.rs
+++ b/crates/fict-emit/src/conditional_return.rs
@@ -1,0 +1,156 @@
+use crate::{
+    EmitOperation, EmitTemporary, EmitTemporaryId, RuntimeHelper, name_allocator::NameAllocator,
+};
+use fict_hir::{
+    FunctionKind, HirFunction, HirInstructionKind, PlaceBase, SourceSpan, TerminatorKind, ValueId,
+};
+use fict_reactivity::{StructuredConstructKind, StructurizeAnalysis};
+use std::collections::BTreeSet;
+pub(crate) fn lower_conditional_returns(
+    function: &HirFunction,
+    control_flow: &StructurizeAnalysis,
+    temporaries: &mut Vec<EmitTemporary>,
+    names: &mut NameAllocator,
+    operations: &mut Vec<EmitOperation>,
+) {
+    if function.kind != FunctionKind::Component {
+        return;
+    }
+    let mut plans = Vec::new();
+    for block in &function.blocks {
+        let TerminatorKind::Return { value: Some(value) } = block.terminator.kind else {
+            continue;
+        };
+        let Some(instruction) = function.instruction_for_result(value) else {
+            continue;
+        };
+        let HirInstructionKind::Conditional {
+            test,
+            consequent,
+            alternate,
+        } = &instruction.kind
+        else {
+            continue;
+        };
+        let Some(test_span) = function.values[test.as_usize()].origin.primary_span else {
+            continue;
+        };
+        if reactive_test(function, operations, test_span)
+            && jsx_value(function, *consequent)
+            && jsx_value(function, *alternate)
+            && consequent != alternate
+        {
+            plans.push(instruction.origin);
+        }
+    }
+    for construct in control_flow
+        .top_level_constructs
+        .iter()
+        .filter_map(|id| control_flow.constructs.get(*id as usize))
+    {
+        if !matches!(construct.kind, StructuredConstructKind::Conditional { .. }) {
+            continue;
+        }
+        let block = &function.blocks[construct.header.as_usize()];
+        let Some(hint) = &block.source_hint else {
+            continue;
+        };
+        let TerminatorKind::Branch {
+            test,
+            consequent,
+            alternate,
+        } = block.terminator.kind
+        else {
+            continue;
+        };
+        let Some(test_span) = function.values[test.as_usize()].origin.primary_span else {
+            continue;
+        };
+        if !reactive_test(function, operations, test_span) {
+            continue;
+        }
+        let Some(consequent) = returned_jsx(function, consequent) else {
+            continue;
+        };
+        let Some(alternate) = returned_jsx(function, alternate) else {
+            continue;
+        };
+        if consequent != alternate {
+            plans.push(hint.origin);
+        }
+    }
+    for origin in plans {
+        let id = EmitTemporaryId::new(u32::try_from(temporaries.len()).unwrap_or(u32::MAX));
+        temporaries.push(EmitTemporary {
+            id,
+            name: names.allocate("__fict_cond_return"),
+            origin,
+        });
+        operations.push(EmitOperation::ConditionalReturn {
+            target: id,
+            helper: RuntimeHelper::Conditional,
+            create_helper: RuntimeHelper::CreateElement,
+            cleanup_helper: RuntimeHelper::OnDestroy,
+            origin,
+        });
+    }
+}
+fn reactive_test(
+    function: &HirFunction,
+    operations: &[EmitOperation],
+    test_span: SourceSpan,
+) -> bool {
+    let contains =
+        |span: SourceSpan| test_span.start() <= span.start() && span.end() <= test_span.end();
+    operations.iter().any(|operation| {
+        matches!(operation, EmitOperation::ReadReactive { origin, .. }
+            if origin.primary_span.is_some_and(contains))
+    }) || function.parameters.iter().any(|parameter| {
+        parameter
+            .object_properties
+            .iter()
+            .flatten()
+            .flat_map(|property| &property.references)
+            .any(|origin| origin.primary_span.is_some_and(contains))
+    }) || function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .any(|instruction| {
+            let HirInstructionKind::Read { place } = &instruction.kind else {
+                return false;
+            };
+            let local = match place.base {
+                PlaceBase::Local(local) => local,
+                PlaceBase::Ssa(name) => name.local,
+                PlaceBase::Global(_) | PlaceBase::Value(_) => return false,
+            };
+            function
+                .parameters
+                .iter()
+                .any(|parameter| parameter.local == local)
+                && instruction.origin.primary_span.is_some_and(contains)
+        })
+}
+fn jsx_value(function: &HirFunction, value: ValueId) -> bool {
+    function
+        .instruction_for_result(value)
+        .is_some_and(|instruction| matches!(instruction.kind, HirInstructionKind::Jsx { .. }))
+}
+fn returned_jsx(function: &HirFunction, start: fict_hir::BlockId) -> Option<ValueId> {
+    let mut current = start;
+    let mut visited = BTreeSet::new();
+    loop {
+        if !visited.insert(current) {
+            return None;
+        }
+        let block = function.blocks.get(current.as_usize())?;
+        match block.terminator.kind {
+            TerminatorKind::Return { value: Some(value) } if jsx_value(function, value) => {
+                return Some(value);
+            }
+            TerminatorKind::Goto { target } if block.instructions.is_empty() => current = target,
+            _ => return None,
+        }
+    }
+}

--- a/crates/fict-emit/src/ir.rs
+++ b/crates/fict-emit/src/ir.rs
@@ -253,6 +253,13 @@ pub enum EmitOperation {
         helper: RuntimeHelper,
         origin: Origin,
     },
+    /// Turn a derived declaration into an accessor; omit `helper` for `use no memo`.
+    CreateDerived {
+        slot: EmitSlotId,
+        source_result: ValueId,
+        helper: Option<RuntimeHelper>,
+        origin: Origin,
+    },
     /// Associate a preserved runtime call (`$store`, `resource`, `createSelector`) with a stable
     /// compiler slot without replacing the executable call.
     TrackRuntimeReactive {
@@ -318,6 +325,7 @@ pub enum EmitOperation {
         local: String,
         html: String,
         namespace: DomNamespace,
+        force_fragment: bool,
         helper: RuntimeHelper,
         origin: Origin,
     },
@@ -486,7 +494,8 @@ impl EmitOperation {
             | Self::KeyedChild { helper, .. }
             | Self::KeyedList { helper, .. }
             | Self::ResolveElement { helper, .. } => Some(*helper),
-            Self::ReadReactive { helper, .. }
+            Self::CreateDerived { helper, .. }
+            | Self::ReadReactive { helper, .. }
             | Self::CreateVNode {
                 fragment_helper: helper,
                 ..
@@ -682,6 +691,7 @@ impl EmitOperation {
             }
             Self::Return { value, .. } => value.iter().for_each(visit),
             Self::PreserveHir { .. }
+            | Self::CreateDerived { .. }
             | Self::TrackRuntimeReactive { .. }
             | Self::ReadReactive { .. }
             | Self::CreateVNode { .. }

--- a/crates/fict-emit/src/ir.rs
+++ b/crates/fict-emit/src/ir.rs
@@ -249,6 +249,7 @@ pub enum EmitOperation {
         slot: EmitSlotId,
         source_result: ValueId,
         local: Option<LocalId>,
+        name: Option<String>,
         initializer: Option<EmitValueRef>,
         helper: RuntimeHelper,
         origin: Origin,
@@ -423,6 +424,14 @@ pub enum EmitOperation {
         cleanup: CleanupOwner,
         origin: Origin,
     },
+    /// Replace an authored reactive `if`/return pair with a root conditional binding.
+    ConditionalReturn {
+        target: EmitTemporaryId,
+        helper: RuntimeHelper,
+        create_helper: RuntimeHelper,
+        cleanup_helper: RuntimeHelper,
+        origin: Origin,
+    },
     /// Materialize a binding-aware keyed `.map()` child between template-owned markers.
     KeyedChild {
         target: EmitTemporaryId,
@@ -491,6 +500,7 @@ impl EmitOperation {
             | Self::BindRef { helper, .. }
             | Self::Insert { helper, .. }
             | Self::Conditional { helper, .. }
+            | Self::ConditionalReturn { helper, .. }
             | Self::KeyedChild { helper, .. }
             | Self::KeyedList { helper, .. }
             | Self::ResolveElement { helper, .. } => Some(*helper),
@@ -541,6 +551,7 @@ impl EmitOperation {
             Self::Insert { create_helper, .. } => Some(*create_helper),
             Self::BindEvent { cleanup_helper, .. } => *cleanup_helper,
             Self::Conditional { create_helper, .. } => Some(*create_helper),
+            Self::ConditionalReturn { create_helper, .. } => Some(*create_helper),
             Self::KeyedChild { cleanup_helper, .. } => Some(*cleanup_helper),
             Self::InvokeComponent {
                 prop_helper: Some(_),
@@ -555,6 +566,7 @@ impl EmitOperation {
     pub const fn tertiary_helper(&self) -> Option<RuntimeHelper> {
         match self {
             Self::Conditional { cleanup_helper, .. } => Some(*cleanup_helper),
+            Self::ConditionalReturn { cleanup_helper, .. } => Some(*cleanup_helper),
             Self::Insert {
                 fragment_helper, ..
             } => *fragment_helper,
@@ -631,6 +643,7 @@ impl EmitOperation {
             | Self::InvokeComponent { target, .. }
             | Self::CreateElement { target, .. }
             | Self::Conditional { target, .. }
+            | Self::ConditionalReturn { target, .. }
             | Self::KeyedChild { target, .. }
             | Self::KeyedList { target, .. } => Some(*target),
             Self::UpdateReactive {
@@ -697,6 +710,7 @@ impl EmitOperation {
             | Self::CreateVNode { .. }
             | Self::DeclareTemplate { .. }
             | Self::CloneTemplate { .. }
+            | Self::ConditionalReturn { .. }
             | Self::KeyedChild { .. }
             | Self::ResolveElement { .. } => {}
         }

--- a/crates/fict-emit/src/lib.rs
+++ b/crates/fict-emit/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! OXC-independent EmitIR and verified runtime-helper intent for Fict output.
 
+mod conditional_return;
 mod ir;
 mod lower;
 mod name_allocator;

--- a/crates/fict-emit/src/lower.rs
+++ b/crates/fict-emit/src/lower.rs
@@ -4,14 +4,17 @@ use fict_diagnostics::{
     Diagnostic, DiagnosticBundle, DiagnosticCode, DiagnosticSeverity, GuaranteeClass,
 };
 use fict_hir::{
-    ArrayElement, CallHost, FictMacroKind, FunctionId, FunctionKind, HirFile, HirFunction,
-    HirInstruction, HirInstructionKind, ImportedHookPropertyMatch, ImportedHookReturn,
+    ArrayElement, BindingId, BlockId, CallHost, FictMacroKind, FunctionId, FunctionKind, HirFile,
+    HirFunction, HirInstruction, HirInstructionKind, ImportedHookPropertyMatch, ImportedHookReturn,
     ImportedName, ImportedReactiveKind, JsxAttribute, JsxAttributeValue, JsxChild, JsxElementName,
     JsxExpressionKind, JsxListExpression, JsxListReceiver, JsxNode, LocalId, ObjectEntry,
-    ObjectPropertyKind, PlaceBase, ReactiveCallKind, TemplateId, TerminatorKind, ValueId,
+    ObjectPropertyKind, Origin, PlaceBase, ReactiveCallKind, TemplateId, TerminatorKind, ValueId,
     ValueKind,
 };
-use fict_reactivity::{ReactiveCycleAnalysis, RegionAnalysis, analyze_cfg, structurize_cfg};
+use fict_reactivity::{
+    ReactiveBindingKind, ReactiveCycleAnalysis, ReactiveScopeAnalysis, RegionAnalysis,
+    SsaDefinitionLocation, analyze_cfg, structurize_cfg,
+};
 
 use crate::{
     CleanupOwner, ComponentChild, ComponentProp, ComponentTarget, ConditionalKind,
@@ -59,9 +62,9 @@ struct ReactiveSite {
 struct HookReturnSite {
     result: ValueId,
     local: Option<LocalId>,
-    import: fict_hir::BindingId,
+    import: BindingId,
     kind: ReactiveSlotKind,
-    origin: fict_hir::Origin,
+    origin: Origin,
     slot: EmitSlotId,
 }
 
@@ -69,10 +72,10 @@ struct HookReturnSite {
 struct HookMemberSite {
     call: ValueId,
     local: Option<LocalId>,
-    import: fict_hir::BindingId,
+    import: BindingId,
     property: ImportedHookPropertyMatch,
     kind: ReactiveSlotKind,
-    origin: fict_hir::Origin,
+    origin: Origin,
     slot: EmitSlotId,
 }
 
@@ -80,41 +83,41 @@ struct HookMemberSite {
 struct StructuredHookRootSite {
     owner: FunctionId,
     local: LocalId,
-    binding: fict_hir::BindingId,
+    binding: BindingId,
     call: ValueId,
-    import: fict_hir::BindingId,
+    import: BindingId,
     shape: ImportedHookReturn,
-    origin: fict_hir::Origin,
+    origin: Origin,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct CapturedHookMemberSite {
     local: LocalId,
-    binding: fict_hir::BindingId,
+    binding: BindingId,
     owner: FunctionId,
     call: ValueId,
-    import: fict_hir::BindingId,
+    import: BindingId,
     property: ImportedHookPropertyMatch,
     kind: ReactiveSlotKind,
-    origin: fict_hir::Origin,
+    origin: Origin,
     slot: EmitSlotId,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct ReactiveBindingSite {
     owner: FunctionId,
-    binding: fict_hir::BindingId,
+    binding: BindingId,
     kind: ReactiveSlotKind,
-    origin: fict_hir::Origin,
+    origin: Origin,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct CrossFunctionFacts<'a> {
-    reactive_bindings: &'a BTreeMap<fict_hir::BindingId, ReactiveBindingSite>,
-    structured_hook_roots: &'a BTreeMap<fict_hir::BindingId, StructuredHookRootSite>,
-    structured_hook_members:
-        &'a BTreeMap<(fict_hir::BindingId, ImportedHookPropertyMatch), fict_hir::Origin>,
-    list_item_bindings: &'a BTreeSet<fict_hir::BindingId>,
+    reactive_bindings: &'a BTreeMap<BindingId, ReactiveBindingSite>,
+    structured_hook_roots: &'a BTreeMap<BindingId, StructuredHookRootSite>,
+    structured_hook_members: &'a BTreeMap<(BindingId, ImportedHookPropertyMatch), Origin>,
+    list_item_bindings: &'a BTreeSet<BindingId>,
+    jsx_getter_bindings: &'a BTreeSet<BindingId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,9 +131,10 @@ pub fn lower_no_jsx(
     hir: &HirFile,
     regions: &[RegionAnalysis],
     cycles: &[ReactiveCycleAnalysis],
+    scopes: Option<&[ReactiveScopeAnalysis]>,
     options: NoJsxLoweringOptions,
 ) -> Result<EmitProgram, DiagnosticBundle> {
-    lower_program(hir, regions, cycles, options, false)
+    lower_program(hir, regions, cycles, scopes, options, false)
 }
 
 /// Lower Core intrinsic JSX in addition to no-JSX reactivity.
@@ -138,22 +142,27 @@ pub fn lower_core(
     hir: &HirFile,
     regions: &[RegionAnalysis],
     cycles: &[ReactiveCycleAnalysis],
+    scopes: Option<&[ReactiveScopeAnalysis]>,
     options: NoJsxLoweringOptions,
 ) -> Result<EmitProgram, DiagnosticBundle> {
-    lower_program(hir, regions, cycles, options, true)
+    lower_program(hir, regions, cycles, scopes, options, true)
 }
 
 fn lower_program(
     hir: &HirFile,
     regions: &[RegionAnalysis],
     cycles: &[ReactiveCycleAnalysis],
+    scopes: Option<&[ReactiveScopeAnalysis]>,
     options: NoJsxLoweringOptions,
     allow_jsx: bool,
 ) -> Result<EmitProgram, DiagnosticBundle> {
-    if regions.len() != hir.functions.len() || cycles.len() != hir.functions.len() {
+    if regions.len() != hir.functions.len()
+        || cycles.len() != hir.functions.len()
+        || scopes.is_some_and(|scopes| scopes.len() != hir.functions.len())
+    {
         return Err(DiagnosticBundle::new(vec![lower_error(
             "FICT-EMIT-ANALYSIS",
-            "no-JSX lowering requires final region and cycle analysis for every function",
+            "lowering requires final region, cycle, and supplied scope analysis for every function",
             GuaranteeClass::Internal,
         )]));
     }
@@ -169,15 +178,26 @@ fn lower_program(
             GuaranteeClass::Fallback,
         )]));
     }
-    let reactive_bindings = collect_reactive_binding_sites(hir)?;
+    let reactive_bindings = collect_reactive_binding_sites(hir, scopes)?;
     let structured_hook_roots = collect_structured_hook_root_sites(hir)?;
     let structured_hook_members = collect_structured_hook_member_uses(hir, &structured_hook_roots);
-    let list_item_bindings = collect_jsx_list_item_bindings(hir);
+    let list_item_bindings = hir.jsx_list_item_bindings();
+    let mut jsx_getter_bindings = list_item_bindings.clone();
+    jsx_getter_bindings.extend(reactive_bindings.keys().copied());
+    for (function, analysis) in hir.functions.iter().zip(scopes.into_iter().flatten()) {
+        jsx_getter_bindings.extend(
+            analysis
+                .bindings
+                .iter()
+                .filter_map(|fact| function.locals[fact.name.local.as_usize()].binding),
+        );
+    }
     let facts = CrossFunctionFacts {
         reactive_bindings: &reactive_bindings,
         structured_hook_roots: &structured_hook_roots,
         structured_hook_members: &structured_hook_members,
         list_item_bindings: &list_item_bindings,
+        jsx_getter_bindings: &jsx_getter_bindings,
     };
     let mut functions = Vec::with_capacity(hir.functions.len());
     for (function_index, function) in hir.functions.iter().enumerate() {
@@ -200,6 +220,7 @@ fn lower_program(
             hir,
             FunctionId::new(count_u32(function_index)),
             &regions[function_index],
+            scopes.map(|scopes| &scopes[function_index]),
             &facts,
             allow_jsx,
             options.fine_grained_dom,
@@ -363,9 +384,78 @@ fn declaration_initializer(
     }
 }
 
+fn derived_declarations(
+    function: &HirFunction,
+    scopes: Option<&ReactiveScopeAnalysis>,
+) -> Vec<(ValueId, LocalId, Origin)> {
+    use HirInstructionKind as K;
+    use ReactiveBindingKind::{Alias, Derived};
+    let Some(scopes) = scopes else {
+        return Vec::new();
+    };
+    if !matches!(
+        function.kind,
+        FunctionKind::Component | FunctionKind::Hook | FunctionKind::ReactiveScope
+    ) {
+        return Vec::new();
+    }
+    let reassigned = reassigned_locals(function);
+    let mut declarations = BTreeMap::new();
+    for (span, site) in scopes.bindings.iter().filter_map(|fact| {
+        if !matches!(fact.kind, Alias | Derived) || reassigned.contains(&fact.name.local) {
+            return None;
+        }
+        let SsaDefinitionLocation::Instruction { block, instruction } = fact.location else {
+            return None;
+        };
+        let source = &function.blocks[block.as_usize()].instructions[instruction as usize];
+        let (result, local) = declaration_initializer(function, source)?;
+        if function
+            .instruction_for_result(result)
+            .is_some_and(|instruction| {
+                matches!(
+                    instruction.kind,
+                    K::Write { .. }
+                        | K::ReadWrite { .. }
+                        | K::PatternAssignment { .. }
+                        | K::Iteration { .. }
+                        | K::Delete { .. }
+                        | K::Await { .. }
+                        | K::Yield { .. }
+                )
+            })
+        {
+            return None;
+        }
+        let origin = function.values[result.as_usize()].origin;
+        (local == fact.name.local).then_some((origin.primary_span?, (result, local, origin)))
+    }) {
+        declarations
+            .entry(span)
+            .and_modify(|site| *site = None)
+            .or_insert(Some(site));
+    }
+    declarations.into_values().flatten().collect()
+}
+
+fn insert_reactive_binding_site(
+    sites: &mut BTreeMap<BindingId, ReactiveBindingSite>,
+    site: ReactiveBindingSite,
+) -> Result<(), DiagnosticBundle> {
+    if sites.insert(site.binding, site).is_some() {
+        return Err(DiagnosticBundle::new(vec![lower_error(
+            "FICT-EMIT-REACTIVE-BINDING",
+            "one semantic binding cannot own multiple reactive creation sites",
+            GuaranteeClass::Internal,
+        )]));
+    }
+    Ok(())
+}
+
 fn collect_reactive_binding_sites(
     hir: &HirFile,
-) -> Result<BTreeMap<fict_hir::BindingId, ReactiveBindingSite>, DiagnosticBundle> {
+    scopes: Option<&[ReactiveScopeAnalysis]>,
+) -> Result<BTreeMap<BindingId, ReactiveBindingSite>, DiagnosticBundle> {
     let mut sites = BTreeMap::new();
     for (function_index, function) in hir.functions.iter().enumerate() {
         let owner = FunctionId::new(count_u32(function_index));
@@ -403,23 +493,31 @@ fn collect_reactive_binding_sites(
             else {
                 continue;
             };
-            if sites
-                .insert(
+            insert_reactive_binding_site(
+                &mut sites,
+                ReactiveBindingSite {
+                    owner,
                     binding,
+                    kind: slot_kind,
+                    origin: instruction.origin,
+                },
+            )?;
+        }
+        if let Some(scopes) = scopes {
+            for (_, local, origin) in derived_declarations(function, Some(&scopes[function_index]))
+            {
+                let Some(binding) = function.locals[local.as_usize()].binding else {
+                    continue;
+                };
+                insert_reactive_binding_site(
+                    &mut sites,
                     ReactiveBindingSite {
                         owner,
                         binding,
-                        kind: slot_kind,
-                        origin: instruction.origin,
+                        kind: ReactiveSlotKind::Memo,
+                        origin,
                     },
-                )
-                .is_some()
-            {
-                return Err(DiagnosticBundle::new(vec![lower_error(
-                    "FICT-EMIT-REACTIVE-BINDING",
-                    "one semantic binding cannot own multiple reactive creation sites",
-                    GuaranteeClass::Internal,
-                )]));
+                )?;
             }
         }
     }
@@ -428,7 +526,7 @@ fn collect_reactive_binding_sites(
 
 fn collect_structured_hook_root_sites(
     hir: &HirFile,
-) -> Result<BTreeMap<fict_hir::BindingId, StructuredHookRootSite>, DiagnosticBundle> {
+) -> Result<BTreeMap<BindingId, StructuredHookRootSite>, DiagnosticBundle> {
     let mut sites = BTreeMap::new();
     for (function_index, function) in hir.functions.iter().enumerate() {
         let owner = FunctionId::new(count_u32(function_index));
@@ -495,8 +593,8 @@ fn collect_structured_hook_root_sites(
 
 fn collect_structured_hook_member_uses(
     hir: &HirFile,
-    roots: &BTreeMap<fict_hir::BindingId, StructuredHookRootSite>,
-) -> BTreeMap<(fict_hir::BindingId, ImportedHookPropertyMatch), fict_hir::Origin> {
+    roots: &BTreeMap<BindingId, StructuredHookRootSite>,
+) -> BTreeMap<(BindingId, ImportedHookPropertyMatch), Origin> {
     let mut uses = BTreeMap::new();
     for function in &hir.functions {
         for instruction in function.blocks.iter().flat_map(|block| &block.instructions) {
@@ -524,6 +622,7 @@ fn lower_function(
     hir: &HirFile,
     function_id: FunctionId,
     regions: &RegionAnalysis,
+    scopes: Option<&ReactiveScopeAnalysis>,
     facts: &CrossFunctionFacts<'_>,
     allow_jsx: bool,
     fine_grained_dom: bool,
@@ -533,6 +632,7 @@ fn lower_function(
         structured_hook_roots,
         structured_hook_members,
         list_item_bindings,
+        jsx_getter_bindings,
     } = *facts;
     let function = &hir.functions[function_id.as_usize()];
     let declarations_by_value: BTreeMap<_, _> = function
@@ -569,6 +669,12 @@ fn lower_function(
             });
         }
     }
+    let mut next_slot = sites.len();
+    let mut allocate_slot = || {
+        let slot = EmitSlotId::new(count_u32(next_slot));
+        next_slot = next_slot.saturating_add(1);
+        slot
+    };
     let site_by_result: BTreeMap<_, _> = sites.iter().map(|site| (site.result, *site)).collect();
     let macro_results: BTreeSet<_> = sites
         .iter()
@@ -632,17 +738,14 @@ fn lower_function(
                 instruction.origin,
             ))
         })
-        .enumerate()
-        .map(
-            |(index, (result, local, import, kind, origin))| HookReturnSite {
-                result,
-                local,
-                import,
-                kind,
-                origin,
-                slot: EmitSlotId::new(count_u32(sites.len().saturating_add(index))),
-            },
-        )
+        .map(|(result, local, import, kind, origin)| HookReturnSite {
+            result,
+            local,
+            import,
+            kind,
+            origin,
+            slot: allocate_slot(),
+        })
         .collect();
     let hook_return_by_result: BTreeMap<_, _> = hook_return_sites
         .iter()
@@ -683,9 +786,8 @@ fn lower_function(
     }
     let hook_member_sites: Vec<_> = hook_member_uses
         .into_iter()
-        .enumerate()
         .map(
-            |(index, ((call, property), (local, import, origin)))| HookMemberSite {
+            |((call, property), (local, import, origin))| HookMemberSite {
                 call,
                 local,
                 import,
@@ -696,12 +798,7 @@ fn lower_function(
                     ImportedReactiveKind::Store => unreachable!("stores are not accessor slots"),
                 },
                 origin,
-                slot: EmitSlotId::new(count_u32(
-                    sites
-                        .len()
-                        .saturating_add(hook_return_sites.len())
-                        .saturating_add(index),
-                )),
+                slot: allocate_slot(),
             },
         )
         .collect();
@@ -739,32 +836,23 @@ fn lower_function(
     }
     let captured_hook_member_sites: Vec<_> = captured_hook_member_uses
         .into_iter()
-        .enumerate()
         .map(
-            |(index, ((local, property), (binding, owner, call, import, origin)))| {
-                CapturedHookMemberSite {
-                    local,
-                    binding,
-                    owner,
-                    call,
-                    import,
-                    property,
-                    kind: match property.kind {
-                        ImportedReactiveKind::Signal => ReactiveSlotKind::Signal,
-                        ImportedReactiveKind::Memo => ReactiveSlotKind::Memo,
-                        ImportedReactiveKind::Store => {
-                            unreachable!("stores are not captured accessor slots")
-                        }
-                    },
-                    origin,
-                    slot: EmitSlotId::new(count_u32(
-                        sites
-                            .len()
-                            .saturating_add(hook_return_sites.len())
-                            .saturating_add(hook_member_sites.len())
-                            .saturating_add(index),
-                    )),
-                }
+            |((local, property), (binding, owner, call, import, origin))| CapturedHookMemberSite {
+                local,
+                binding,
+                owner,
+                call,
+                import,
+                property,
+                kind: match property.kind {
+                    ImportedReactiveKind::Signal => ReactiveSlotKind::Signal,
+                    ImportedReactiveKind::Memo => ReactiveSlotKind::Memo,
+                    ImportedReactiveKind::Store => {
+                        unreachable!("stores are not captured accessor slots")
+                    }
+                },
+                origin,
+                slot: allocate_slot(),
             },
         )
         .collect();
@@ -781,21 +869,7 @@ fn lower_function(
             let site = reactive_bindings.get(&binding).copied()?;
             (site.owner != function_id).then_some((local.id, site))
         })
-        .enumerate()
-        .map(|(index, (local, site))| {
-            (
-                local,
-                site,
-                EmitSlotId::new(count_u32(
-                    sites
-                        .len()
-                        .saturating_add(hook_return_sites.len())
-                        .saturating_add(hook_member_sites.len())
-                        .saturating_add(captured_hook_member_sites.len())
-                        .saturating_add(index),
-                )),
-            )
-        })
+        .map(|(local, site)| (local, site, allocate_slot()))
         .collect();
     let imported_sites: Vec<_> = function
         .locals
@@ -819,24 +893,7 @@ fn lower_function(
                 local.origin,
             ))
         })
-        .enumerate()
-        .map(|(index, (local, binding, kind, origin))| {
-            (
-                local,
-                binding,
-                kind,
-                origin,
-                EmitSlotId::new(count_u32(
-                    sites
-                        .len()
-                        .saturating_add(hook_return_sites.len())
-                        .saturating_add(hook_member_sites.len())
-                        .saturating_add(captured_hook_member_sites.len())
-                        .saturating_add(captured_sites.len())
-                        .saturating_add(index),
-                )),
-            )
-        })
+        .map(|(local, binding, kind, origin)| (local, binding, kind, origin, allocate_slot()))
         .collect();
     let mut imported_member_uses = BTreeMap::new();
     for instruction in function.blocks.iter().flat_map(|block| &block.instructions) {
@@ -862,9 +919,8 @@ fn lower_function(
     }
     let imported_member_sites: Vec<_> = imported_member_uses
         .into_iter()
-        .enumerate()
         .map(
-            |(index, ((local, member_index), (binding, kind, accessor_depth, origin)))| {
+            |((local, member_index), (binding, kind, accessor_depth, origin))| {
                 (
                     local,
                     member_index,
@@ -872,20 +928,24 @@ fn lower_function(
                     kind,
                     accessor_depth,
                     origin,
-                    EmitSlotId::new(count_u32(
-                        sites
-                            .len()
-                            .saturating_add(hook_return_sites.len())
-                            .saturating_add(hook_member_sites.len())
-                            .saturating_add(captured_hook_member_sites.len())
-                            .saturating_add(captured_sites.len())
-                            .saturating_add(imported_sites.len())
-                            .saturating_add(index),
-                    )),
+                    allocate_slot(),
                 )
             },
         )
         .collect();
+    let derived_start = sites.len();
+    let owned_reactive_locals: BTreeSet<_> = sites.iter().filter_map(|site| site.local).collect();
+    sites.extend(
+        derived_declarations(function, scopes)
+            .into_iter()
+            .filter(|(_, local, _)| !owned_reactive_locals.contains(local))
+            .map(|(result, local, _)| ReactiveSite {
+                result,
+                local: Some(local),
+                kind: ReactiveSiteKind::Macro(FictMacroKind::Memo),
+                slot: allocate_slot(),
+            }),
+    );
     let imported_member_slots: BTreeMap<_, _> = imported_member_sites
         .iter()
         .map(|(local, member_index, _, kind, accessor_depth, _, slot)| {
@@ -1025,6 +1085,7 @@ fn lower_function(
             origin: *origin,
         },
     ));
+    slots.sort_unstable_by_key(|slot| slot.id);
     let mut temporary_names = NameAllocator::new(
         hir.bindings
             .iter()
@@ -1039,7 +1100,16 @@ fn lower_function(
     let props = lower_component_props_plan(hir, function, &mut temporary_names)?;
     let mut temporaries = Vec::new();
     let mut value_temporaries = BTreeMap::new();
-    let mut operations = Vec::new();
+    let mut operations: Vec<_> = sites[derived_start..]
+        .iter()
+        .map(|site| EmitOperation::CreateDerived {
+            slot: site.slot,
+            source_result: site.result,
+            helper: (!function.flags.no_memo)
+                .then(|| creation_helper(function.kind, FictMacroKind::Memo)),
+            origin: reactive_site_origin(function, site.result),
+        })
+        .collect();
     let hook_return_accessor_reads = hook_return_accessor_reads(function);
     let mut declared_templates = BTreeSet::new();
     let cleanup = regions
@@ -1406,6 +1476,7 @@ fn lower_function(
                             cleanup,
                             reactive_bindings,
                             list_item_bindings,
+                            jsx_getter_bindings,
                         )?;
                     } else {
                         let Some(source_result) = instruction.result else {
@@ -1485,7 +1556,7 @@ fn jsx_contains_direct_yield(function: &HirFunction, jsx: &HirInstruction) -> bo
 
 fn lower_component_props_plan(
     hir: &HirFile,
-    function: &fict_hir::HirFunction,
+    function: &HirFunction,
     names: &mut NameAllocator,
 ) -> Result<Option<EmitPropsPlan>, DiagnosticBundle> {
     if function.kind != FunctionKind::Component {
@@ -1588,7 +1659,7 @@ enum TemplateBinding {
         path: Vec<u32>,
         name: String,
         value: fict_hir::LiteralValue,
-        origin: fict_hir::Origin,
+        origin: Origin,
     },
     Evaluate {
         value: ValueId,
@@ -1609,7 +1680,7 @@ enum TemplateBinding {
     ComponentChild {
         parent_path: Vec<u32>,
         marker_path: Vec<u32>,
-        origin: fict_hir::Origin,
+        origin: Origin,
         namespace: DomNamespace,
     },
     Conditional {
@@ -1646,6 +1717,7 @@ enum TemplateBinding {
 struct SerializedTemplate {
     html: String,
     namespace: DomNamespace,
+    force_fragment: bool,
     bindings: Vec<TemplateBinding>,
 }
 
@@ -1654,15 +1726,16 @@ fn lower_jsx_instruction(
     hir: &HirFile,
     function_id: FunctionId,
     template_id: TemplateId,
-    instruction: &fict_hir::HirInstruction,
+    instruction: &HirInstruction,
     declared_templates: &mut BTreeSet<TemplateId>,
     temporaries: &mut Vec<EmitTemporary>,
     temporary_names: &mut NameAllocator,
     value_temporaries: &mut BTreeMap<ValueId, EmitTemporaryId>,
     operations: &mut Vec<EmitOperation>,
     cleanup: CleanupOwner,
-    reactive_bindings: &BTreeMap<fict_hir::BindingId, ReactiveBindingSite>,
-    list_item_bindings: &BTreeSet<fict_hir::BindingId>,
+    reactive_bindings: &BTreeMap<BindingId, ReactiveBindingSite>,
+    list_item_bindings: &BTreeSet<BindingId>,
+    jsx_getter_bindings: &BTreeSet<BindingId>,
 ) -> Result<(), DiagnosticBundle> {
     let Some(template) = hir.templates.get(template_id.as_usize()) else {
         return Err(DiagnosticBundle::new(vec![lower_error(
@@ -1700,6 +1773,7 @@ fn lower_jsx_instruction(
         value_temporaries,
         operations,
         &mut component_targets,
+        jsx_getter_bindings,
     )?;
     if root_is_component {
         return Ok(());
@@ -1715,6 +1789,7 @@ fn lower_jsx_instruction(
             local: local.clone(),
             html: serialized.html,
             namespace: serialized.namespace,
+            force_fragment: serialized.force_fragment,
             helper: RuntimeHelper::Template,
             origin: template.origin,
         });
@@ -2106,6 +2181,7 @@ fn register_component_nodes(
     value_temporaries: &mut BTreeMap<ValueId, EmitTemporaryId>,
     operations: &mut Vec<EmitOperation>,
     component_targets: &mut BTreeMap<(u32, u32), EmitTemporaryId>,
+    jsx_getter_bindings: &BTreeSet<BindingId>,
 ) -> Result<(), DiagnosticBundle> {
     match node {
         JsxNode::Element(element) => {
@@ -2119,6 +2195,7 @@ fn register_component_nodes(
                     temporary_names,
                     value_temporaries,
                     operations,
+                    jsx_getter_bindings,
                 )?;
                 let Some(span) = element.origin.primary_span else {
                     return Err(DiagnosticBundle::new(vec![lower_error(
@@ -2160,6 +2237,7 @@ fn register_component_nodes(
                         value_temporaries,
                         operations,
                         component_targets,
+                        jsx_getter_bindings,
                     )?;
                 }
             }
@@ -2175,6 +2253,7 @@ fn register_component_nodes(
                         value_temporaries,
                         operations,
                         component_targets,
+                        jsx_getter_bindings,
                     )?;
                 }
             }
@@ -2199,12 +2278,29 @@ fn register_component_nodes(
                         value_temporaries,
                         operations,
                         component_targets,
+                        jsx_getter_bindings,
                     )?;
                 }
             }
         }
     }
     Ok(())
+}
+
+fn jsx_value_needs_getter(
+    hir: &HirFile,
+    function: &HirFunction,
+    value: ValueId,
+    bindings: &BTreeSet<BindingId>,
+) -> bool {
+    let ValueKind::SyntaxFragment(fragment) = function.values[value.as_usize()].kind else {
+        return false;
+    };
+    hir.syntax_fragments[fragment.as_usize()]
+        .summary
+        .referenced_bindings
+        .iter()
+        .any(|binding| bindings.contains(binding))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2217,7 +2313,9 @@ fn lower_component_operation(
     temporary_names: &mut NameAllocator,
     value_temporaries: &mut BTreeMap<ValueId, EmitTemporaryId>,
     operations: &mut Vec<EmitOperation>,
+    jsx_getter_bindings: &BTreeSet<BindingId>,
 ) -> Result<EmitTemporaryId, DiagnosticBundle> {
+    let function = &hir.functions[function_id.as_usize()];
     let resettable_boundary = is_runtime_resettable_boundary(hir, &element.name);
     let component = match &element.name {
         JsxElementName::Component(binding) => ComponentTarget::Binding(*binding),
@@ -2252,16 +2350,13 @@ fn lower_component_operation(
                     } => (
                         lower_value(*value, value_temporaries),
                         !function_like
-                            && !matches!(
-                                hir.functions[function_id.as_usize()].values[value.as_usize()].kind,
-                                ValueKind::Literal(_)
-                            ),
+                            && jsx_value_needs_getter(hir, function, *value, jsx_getter_bindings),
                         *function_like,
                     ),
                     JsxAttributeValue::Node(node) => {
                         props.push(ComponentProp::Node {
                             name: name.clone(),
-                            origin: jsx_node_origin(node),
+                            origin: node.origin(),
                         });
                         continue;
                     }
@@ -2286,7 +2381,8 @@ fn lower_component_operation(
             JsxAttribute::Spread { value, getter, .. } => {
                 props.push(ComponentProp::Spread {
                     value: lower_value(*value, value_temporaries),
-                    getter: *getter,
+                    getter: *getter
+                        || jsx_value_needs_getter(hir, function, *value, jsx_getter_bindings),
                 });
             }
         }
@@ -2306,21 +2402,15 @@ fn lower_component_operation(
             } => ComponentChild::Value {
                 value: lower_value(*value, value_temporaries),
                 getter: !function_like
-                    && !matches!(
-                        hir.functions[function_id.as_usize()].values[value.as_usize()].kind,
-                        ValueKind::Literal(_)
-                    ),
+                    && jsx_value_needs_getter(hir, function, *value, jsx_getter_bindings),
                 non_reactive: *function_like,
             },
             JsxChild::Spread { value, .. } => ComponentChild::Value {
                 value: lower_value(*value, value_temporaries),
-                getter: !matches!(
-                    hir.functions[function_id.as_usize()].values[value.as_usize()].kind,
-                    ValueKind::Literal(_)
-                ),
+                getter: jsx_value_needs_getter(hir, function, *value, jsx_getter_bindings),
                 non_reactive: false,
             },
-            JsxChild::Node(node) => ComponentChild::Node(jsx_node_origin(node)),
+            JsxChild::Node(node) => ComponentChild::Node(node.origin()),
         };
         children.push(child);
     }
@@ -2423,65 +2513,10 @@ fn is_runtime_resettable_boundary(hir: &HirFile, name: &JsxElementName) -> bool 
     }
 }
 
-fn jsx_node_origin(node: &JsxNode) -> fict_hir::Origin {
-    match node {
-        JsxNode::Element(element) => element.origin,
-        JsxNode::Fragment { origin, .. } => *origin,
-    }
-}
-
-fn collect_jsx_list_item_bindings(hir: &HirFile) -> BTreeSet<fict_hir::BindingId> {
-    enum Item<'a> {
-        Node(&'a JsxNode),
-        Child(&'a JsxChild),
-    }
-
-    let mut bindings = BTreeSet::new();
-    for template in &hir.templates {
-        let mut stack = vec![Item::Node(&template.root)];
-        while let Some(item) = stack.pop() {
-            match item {
-                Item::Node(JsxNode::Element(element)) => {
-                    for attribute in &element.attributes {
-                        if let JsxAttribute::Named {
-                            value: JsxAttributeValue::Node(node),
-                            ..
-                        } = attribute
-                        {
-                            stack.push(Item::Node(node));
-                        }
-                    }
-                    stack.extend(element.children.iter().map(Item::Child));
-                }
-                Item::Node(JsxNode::Fragment { children, .. }) => {
-                    stack.extend(children.iter().map(Item::Child));
-                }
-                Item::Child(JsxChild::Expression {
-                    list: Some(list), ..
-                }) => {
-                    if let Some(binding) = hir
-                        .functions
-                        .get(list.callback.as_usize())
-                        .and_then(|function| function.parameters.first())
-                        .and_then(|parameter| parameter.binding)
-                    {
-                        bindings.insert(binding);
-                    }
-                }
-                Item::Child(JsxChild::Node(node)) => stack.push(Item::Node(node)),
-                Item::Child(
-                    JsxChild::Text { .. } | JsxChild::Expression { .. } | JsxChild::Spread { .. },
-                ) => {}
-            }
-        }
-    }
-    bindings
-}
-
 fn trusted_jsx_list_values(
     root: &JsxNode,
-    reactive_bindings: &BTreeMap<fict_hir::BindingId, ReactiveBindingSite>,
-    list_item_bindings: &BTreeSet<fict_hir::BindingId>,
+    reactive_bindings: &BTreeMap<BindingId, ReactiveBindingSite>,
+    list_item_bindings: &BTreeSet<BindingId>,
 ) -> BTreeSet<ValueId> {
     enum Item<'a> {
         Node(&'a JsxNode),
@@ -2527,8 +2562,8 @@ fn trusted_jsx_list_values(
 
 fn trusted_jsx_list_receiver(
     receiver: JsxListReceiver,
-    reactive_bindings: &BTreeMap<fict_hir::BindingId, ReactiveBindingSite>,
-    list_item_bindings: &BTreeSet<fict_hir::BindingId>,
+    reactive_bindings: &BTreeMap<BindingId, ReactiveBindingSite>,
+    list_item_bindings: &BTreeSet<BindingId>,
 ) -> bool {
     match receiver {
         JsxListReceiver::ArrayLiteral => true,
@@ -2586,6 +2621,7 @@ fn serialize_template_with_lists(
     Ok(SerializedTemplate {
         html,
         namespace,
+        force_fragment: matches!(root, JsxNode::Fragment { .. }),
         bindings,
     })
 }
@@ -3272,7 +3308,7 @@ fn resolved_element(
     temporaries: &mut Vec<EmitTemporary>,
     temporary_names: &mut NameAllocator,
     operations: &mut Vec<EmitOperation>,
-    origin: fict_hir::Origin,
+    origin: Origin,
 ) -> EmitTemporaryId {
     if path.is_empty() {
         return root;
@@ -3481,7 +3517,7 @@ fn is_runtime_helper_call(
             .any(|family| import.source == spec.module_request(family))
 }
 
-fn function_value(function: &fict_hir::HirFunction, value: ValueId) -> Option<FunctionId> {
+fn function_value(function: &HirFunction, value: ValueId) -> Option<FunctionId> {
     match function.values.get(value.as_usize())?.kind {
         ValueKind::Function(function) => Some(function),
         _ => None,
@@ -3515,12 +3551,7 @@ fn collect_hook_return_accessor_reads(
     if !visited.insert(value) {
         return;
     }
-    let Some(instruction) = function
-        .blocks
-        .iter()
-        .flat_map(|block| &block.instructions)
-        .find(|instruction| instruction.result == Some(value))
-    else {
+    let Some(instruction) = function.instruction_for_result(value) else {
         return;
     };
 
@@ -3608,7 +3639,7 @@ fn reassigned_locals(function: &HirFunction) -> BTreeSet<LocalId> {
 
 fn structured_hook_member_by_binding<'a>(
     function: &HirFunction,
-    roots: &'a BTreeMap<fict_hir::BindingId, StructuredHookRootSite>,
+    roots: &'a BTreeMap<BindingId, StructuredHookRootSite>,
     place: &fict_hir::Place,
 ) -> Option<(
     LocalId,
@@ -3626,11 +3657,7 @@ fn imported_reactive_member(
     hir: &HirFile,
     function: &HirFunction,
     place: &fict_hir::Place,
-) -> Option<(
-    LocalId,
-    fict_hir::BindingId,
-    fict_hir::ImportedReactiveMemberMatch,
-)> {
+) -> Option<(LocalId, BindingId, fict_hir::ImportedReactiveMemberMatch)> {
     let local = place_local(place.base)?;
     let binding = function.locals.get(local.as_usize())?.binding?;
     let resolved = hir
@@ -3645,7 +3672,7 @@ fn imported_reactive_member(
 fn imported_hook_direct(
     hir: &HirFile,
     call: &fict_hir::CallInstruction,
-) -> Option<(fict_hir::BindingId, ImportedReactiveKind)> {
+) -> Option<(BindingId, ImportedReactiveKind)> {
     let (binding, shape) = imported_hook_return(hir, call)?;
     let kind = shape.direct_accessor?;
     Some((binding, kind))
@@ -3654,7 +3681,7 @@ fn imported_hook_direct(
 fn imported_hook_return<'a>(
     hir: &'a HirFile,
     call: &fict_hir::CallInstruction,
-) -> Option<(fict_hir::BindingId, &'a ImportedHookReturn)> {
+) -> Option<(BindingId, &'a ImportedHookReturn)> {
     let CallHost::Binding(binding) = call.host else {
         return None;
     };
@@ -3669,13 +3696,13 @@ fn imported_hook_return<'a>(
 }
 
 fn imported_hook_member(
-    calls: &BTreeMap<ValueId, (fict_hir::BindingId, ImportedHookReturn, fict_hir::Origin)>,
+    calls: &BTreeMap<ValueId, (BindingId, ImportedHookReturn, Origin)>,
     locals: &BTreeMap<LocalId, ValueId>,
     place: &fict_hir::Place,
 ) -> Option<(
     ValueId,
     Option<LocalId>,
-    fict_hir::BindingId,
+    BindingId,
     ImportedHookPropertyMatch,
 )> {
     let (call, local) = match place.base {
@@ -3693,7 +3720,7 @@ fn imported_hook_member(
 }
 
 fn reject_imported_hook_member_mutation(
-    calls: &BTreeMap<ValueId, (fict_hir::BindingId, ImportedHookReturn, fict_hir::Origin)>,
+    calls: &BTreeMap<ValueId, (BindingId, ImportedHookReturn, Origin)>,
     locals: &BTreeMap<LocalId, ValueId>,
     place: &fict_hir::Place,
 ) -> Result<(), DiagnosticBundle> {
@@ -3706,7 +3733,7 @@ fn reject_imported_hook_member_mutation(
 fn reject_captured_hook_member_mutation(
     function: &HirFunction,
     function_id: FunctionId,
-    roots: &BTreeMap<fict_hir::BindingId, StructuredHookRootSite>,
+    roots: &BTreeMap<BindingId, StructuredHookRootSite>,
     place: &fict_hir::Place,
 ) -> Result<(), DiagnosticBundle> {
     let Some((_, root, property)) = structured_hook_member_by_binding(function, roots, place)
@@ -3770,7 +3797,7 @@ fn allocate_temporary(
     temporaries: &mut Vec<EmitTemporary>,
     names: &mut NameAllocator,
     preferred: String,
-    origin: fict_hir::Origin,
+    origin: Origin,
 ) -> EmitTemporaryId {
     let id = EmitTemporaryId::new(count_u32(temporaries.len()));
     let name = names.allocate(&preferred);
@@ -3780,9 +3807,9 @@ fn allocate_temporary(
 
 fn preserve(
     operations: &mut Vec<EmitOperation>,
-    block: fict_hir::BlockId,
+    block: BlockId,
     instruction: usize,
-    hir: &fict_hir::HirInstruction,
+    hir: &HirInstruction,
 ) {
     operations.push(EmitOperation::PreserveHir {
         block,
@@ -3791,12 +3818,9 @@ fn preserve(
     });
 }
 
-fn reactive_site_origin(function: &fict_hir::HirFunction, result: ValueId) -> fict_hir::Origin {
+fn reactive_site_origin(function: &HirFunction, result: ValueId) -> Origin {
     function
-        .blocks
-        .iter()
-        .flat_map(|block| &block.instructions)
-        .find(|instruction| instruction.result == Some(result))
+        .instruction_for_result(result)
         .map_or(function.origin, |instruction| instruction.origin)
 }
 
@@ -4153,21 +4177,17 @@ mod namespace_tests {
         let (event, explicit, options) =
             parse_event_attribute("onClickCapturePassiveOnce$").expect("combined event");
         assert_eq!(event, "click");
-        assert!(explicit);
-        assert!(options.capture && options.passive && options.once);
-
+        assert!(explicit && options.capture && options.passive && options.once);
         let (event, explicit, options) =
             parse_event_attribute("onGotPointerCapture$").expect("pointer capture event");
         assert_eq!(event, "gotpointercapture");
         assert!(explicit);
         assert!(options.is_empty());
-
         let (event, explicit, options) =
             parse_event_attribute("onGotPointerCaptureOnce").expect("pointer capture once event");
         assert_eq!(event, "gotpointercapture");
         assert!(!explicit);
         assert!(options.once && !options.capture && !options.passive);
-
         let (event, explicit, options) =
             parse_event_attribute("oncapture:Input$").expect("namespaced capture event");
         assert_eq!(event, "input");

--- a/crates/fict-emit/src/lower.rs
+++ b/crates/fict-emit/src/lower.rs
@@ -1,5 +1,12 @@
-use std::collections::{BTreeMap, BTreeSet};
-
+use crate::{
+    CleanupOwner, ComponentChild, ComponentProp, ComponentTarget, ConditionalKind,
+    DELEGATED_EVENTS, DomBindingKind, DomNamespace, EmitContext, EmitFunction, EmitModulePlan,
+    EmitOperation, EmitProgram, EmitPropBinding, EmitPropCheck, EmitPropMode, EmitPropsDefault,
+    EmitPropsPlan, EmitPropsRest, EmitSlotId, EmitTemporary, EmitTemporaryId, EmitValueRef,
+    EventOptions, PropsOperation, ReactivePatternTarget, ReactiveSlot, ReactiveSlotKind,
+    ReactiveSlotStorage, RuntimeFamily, RuntimeHelper, RuntimeImportIntent,
+    name_allocator::NameAllocator, verify_emit_program,
+};
 use fict_diagnostics::{
     Diagnostic, DiagnosticBundle, DiagnosticCode, DiagnosticSeverity, GuaranteeClass,
 };
@@ -15,17 +22,7 @@ use fict_reactivity::{
     ReactiveBindingKind, ReactiveCycleAnalysis, ReactiveScopeAnalysis, RegionAnalysis,
     SsaDefinitionLocation, analyze_cfg, structurize_cfg,
 };
-
-use crate::{
-    CleanupOwner, ComponentChild, ComponentProp, ComponentTarget, ConditionalKind,
-    DELEGATED_EVENTS, DomBindingKind, DomNamespace, EmitContext, EmitFunction, EmitModulePlan,
-    EmitOperation, EmitProgram, EmitPropBinding, EmitPropCheck, EmitPropMode, EmitPropsDefault,
-    EmitPropsPlan, EmitPropsRest, EmitSlotId, EmitTemporary, EmitTemporaryId, EmitValueRef,
-    EventOptions, PropsOperation, ReactivePatternTarget, ReactiveSlot, ReactiveSlotKind,
-    ReactiveSlotStorage, RuntimeFamily, RuntimeHelper, RuntimeImportIntent,
-    name_allocator::NameAllocator, verify_emit_program,
-};
-
+use std::collections::{BTreeMap, BTreeSet};
 /// Phase-1 Core lowering configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoJsxLoweringOptions {
@@ -38,7 +35,6 @@ pub struct NoJsxLoweringOptions {
     /// Emit fine-grained DOM operations instead of the complete VNode fallback.
     pub fine_grained_dom: bool,
 }
-
 impl Default for NoJsxLoweringOptions {
     fn default() -> Self {
         Self {
@@ -49,7 +45,6 @@ impl Default for NoJsxLoweringOptions {
         }
     }
 }
-
 #[derive(Debug, Clone, Copy)]
 struct ReactiveSite {
     result: ValueId,
@@ -57,7 +52,6 @@ struct ReactiveSite {
     kind: ReactiveSiteKind,
     slot: EmitSlotId,
 }
-
 #[derive(Debug, Clone, Copy)]
 struct HookReturnSite {
     result: ValueId,
@@ -67,7 +61,6 @@ struct HookReturnSite {
     origin: Origin,
     slot: EmitSlotId,
 }
-
 #[derive(Debug, Clone, Copy)]
 struct HookMemberSite {
     call: ValueId,
@@ -78,7 +71,6 @@ struct HookMemberSite {
     origin: Origin,
     slot: EmitSlotId,
 }
-
 #[derive(Debug, Clone)]
 struct StructuredHookRootSite {
     owner: FunctionId,
@@ -89,7 +81,6 @@ struct StructuredHookRootSite {
     shape: ImportedHookReturn,
     origin: Origin,
 }
-
 #[derive(Debug, Clone, Copy)]
 struct CapturedHookMemberSite {
     local: LocalId,
@@ -102,7 +93,6 @@ struct CapturedHookMemberSite {
     origin: Origin,
     slot: EmitSlotId,
 }
-
 #[derive(Debug, Clone, Copy)]
 struct ReactiveBindingSite {
     owner: FunctionId,
@@ -110,7 +100,6 @@ struct ReactiveBindingSite {
     kind: ReactiveSlotKind,
     origin: Origin,
 }
-
 #[derive(Debug, Clone, Copy)]
 struct CrossFunctionFacts<'a> {
     reactive_bindings: &'a BTreeMap<BindingId, ReactiveBindingSite>,
@@ -119,13 +108,11 @@ struct CrossFunctionFacts<'a> {
     list_item_bindings: &'a BTreeSet<BindingId>,
     jsx_getter_bindings: &'a BTreeSet<BindingId>,
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReactiveSiteKind {
     Macro(FictMacroKind),
     Runtime(ReactiveCallKind),
 }
-
 /// Lower state/memo/effect and reactive reads/writes while preserving ordinary HIR.
 pub fn lower_no_jsx(
     hir: &HirFile,
@@ -136,7 +123,6 @@ pub fn lower_no_jsx(
 ) -> Result<EmitProgram, DiagnosticBundle> {
     lower_program(hir, regions, cycles, scopes, options, false)
 }
-
 /// Lower Core intrinsic JSX in addition to no-JSX reactivity.
 pub fn lower_core(
     hir: &HirFile,
@@ -147,7 +133,6 @@ pub fn lower_core(
 ) -> Result<EmitProgram, DiagnosticBundle> {
     lower_program(hir, regions, cycles, scopes, options, true)
 }
-
 fn lower_program(
     hir: &HirFile,
     regions: &[RegionAnalysis],
@@ -341,7 +326,6 @@ fn lower_program(
     verify_emit_program(hir, regions, &program)?;
     Ok(program)
 }
-
 fn module_source_fragment(hir: &HirFile) -> Option<fict_hir::SyntaxFragmentId> {
     hir.functions
         .get(hir.root_function.as_usize())?
@@ -356,7 +340,6 @@ fn module_source_fragment(hir: &HirFile) -> Option<fict_hir::SyntaxFragmentId> {
             _ => None,
         })
 }
-
 fn declaration_initializer(
     function: &HirFunction,
     instruction: &HirInstruction,
@@ -383,7 +366,6 @@ fn declaration_initializer(
         _ => None,
     }
 }
-
 fn derived_declarations(
     function: &HirFunction,
     scopes: Option<&ReactiveScopeAnalysis>,
@@ -437,7 +419,6 @@ fn derived_declarations(
     }
     declarations.into_values().flatten().collect()
 }
-
 fn insert_reactive_binding_site(
     sites: &mut BTreeMap<BindingId, ReactiveBindingSite>,
     site: ReactiveBindingSite,
@@ -451,7 +432,6 @@ fn insert_reactive_binding_site(
     }
     Ok(())
 }
-
 fn collect_reactive_binding_sites(
     hir: &HirFile,
     scopes: Option<&[ReactiveScopeAnalysis]>,
@@ -523,7 +503,6 @@ fn collect_reactive_binding_sites(
     }
     Ok(sites)
 }
-
 fn collect_structured_hook_root_sites(
     hir: &HirFile,
 ) -> Result<BTreeMap<BindingId, StructuredHookRootSite>, DiagnosticBundle> {
@@ -590,7 +569,6 @@ fn collect_structured_hook_root_sites(
     }
     Ok(sites)
 }
-
 fn collect_structured_hook_member_uses(
     hir: &HirFile,
     roots: &BTreeMap<BindingId, StructuredHookRootSite>,
@@ -617,7 +595,6 @@ fn collect_structured_hook_member_uses(
     }
     uses
 }
-
 fn lower_function(
     hir: &HirFile,
     function_id: FunctionId,
@@ -1156,6 +1133,9 @@ fn lower_function(
                             slot: site.slot,
                             source_result: result,
                             local: site.local,
+                            name: site.local.and_then(|local| {
+                                function.locals[local.as_usize()].debug_name.clone()
+                            }),
                             initializer: call
                                 .arguments
                                 .first()
@@ -1514,6 +1494,14 @@ fn lower_function(
             | TerminatorKind::Unreachable => {}
         }
     }
+    let control_flow = structurize_cfg(function, &analyze_cfg(function)?)?;
+    crate::conditional_return::lower_conditional_returns(
+        function,
+        &control_flow,
+        &mut temporaries,
+        &mut temporary_names,
+        &mut operations,
+    );
     let context = operations
         .iter()
         .filter_map(EmitOperation::helper)
@@ -1530,11 +1518,10 @@ fn lower_function(
         slots,
         temporaries,
         regions: regions.top_level_regions.clone(),
-        control_flow: structurize_cfg(function, &analyze_cfg(function)?)?,
+        control_flow,
         operations,
     })
 }
-
 fn jsx_contains_direct_yield(function: &HirFunction, jsx: &HirInstruction) -> bool {
     if !function.flags.is_generator {
         return false;
@@ -1553,7 +1540,6 @@ fn jsx_contains_direct_yield(function: &HirFunction, jsx: &HirInstruction) -> bo
                 })
         })
 }
-
 fn lower_component_props_plan(
     hir: &HirFile,
     function: &HirFunction,
@@ -1640,14 +1626,12 @@ fn lower_component_props_plan(
         helper,
     }))
 }
-
 fn is_scoped_helper(helper: RuntimeHelper) -> bool {
     matches!(
         helper,
         RuntimeHelper::UseSignal | RuntimeHelper::UseMemo | RuntimeHelper::UseEffect
     )
 }
-
 #[derive(Debug)]
 enum TemplateBinding {
     Attribute {
@@ -1712,7 +1696,6 @@ enum TemplateBinding {
         reference: ValueId,
     },
 }
-
 #[derive(Debug)]
 struct SerializedTemplate {
     html: String,
@@ -1720,7 +1703,6 @@ struct SerializedTemplate {
     force_fragment: bool,
     bindings: Vec<TemplateBinding>,
 }
-
 #[allow(clippy::too_many_arguments)]
 fn lower_jsx_instruction(
     hir: &HirFile,
@@ -2169,7 +2151,6 @@ fn lower_jsx_instruction(
     }
     Ok(())
 }
-
 #[allow(clippy::too_many_arguments)]
 fn register_component_nodes(
     hir: &HirFile,
@@ -2286,7 +2267,6 @@ fn register_component_nodes(
     }
     Ok(())
 }
-
 fn jsx_value_needs_getter(
     hir: &HirFile,
     function: &HirFunction,
@@ -2302,7 +2282,6 @@ fn jsx_value_needs_getter(
         .iter()
         .any(|binding| bindings.contains(binding))
 }
-
 #[allow(clippy::too_many_arguments)]
 fn lower_component_operation(
     hir: &HirFile,
@@ -2482,7 +2461,6 @@ fn lower_component_operation(
     });
     Ok(target)
 }
-
 fn is_runtime_resettable_boundary(hir: &HirFile, name: &JsxElementName) -> bool {
     match name {
         JsxElementName::Component(binding) => hir
@@ -2512,7 +2490,6 @@ fn is_runtime_resettable_boundary(hir: &HirFile, name: &JsxElementName) -> bool 
         JsxElementName::Intrinsic(_) | JsxElementName::Dynamic(_) => false,
     }
 }
-
 fn trusted_jsx_list_values(
     root: &JsxNode,
     reactive_bindings: &BTreeMap<BindingId, ReactiveBindingSite>,
@@ -2522,7 +2499,6 @@ fn trusted_jsx_list_values(
         Node(&'a JsxNode),
         Child(&'a JsxChild),
     }
-
     let mut trusted = BTreeSet::new();
     let mut stack = vec![Item::Node(root)];
     while let Some(item) = stack.pop() {
@@ -2559,7 +2535,6 @@ fn trusted_jsx_list_values(
     }
     trusted
 }
-
 fn trusted_jsx_list_receiver(
     receiver: JsxListReceiver,
     reactive_bindings: &BTreeMap<BindingId, ReactiveBindingSite>,
@@ -2587,12 +2562,10 @@ fn trusted_jsx_list_receiver(
             .is_some_and(|site| site.kind == ReactiveSlotKind::Store),
     }
 }
-
 #[cfg(test)]
 fn serialize_template(root: &JsxNode) -> Result<SerializedTemplate, DiagnosticBundle> {
     serialize_template_with_lists(root, &BTreeSet::new())
 }
-
 fn serialize_template_with_lists(
     root: &JsxNode,
     trusted_lists: &BTreeSet<ValueId>,
@@ -2625,7 +2598,6 @@ fn serialize_template_with_lists(
         bindings,
     })
 }
-
 fn serialize_node(
     node: &JsxNode,
     parent_namespace: Option<DomNamespace>,
@@ -2791,7 +2763,6 @@ fn serialize_node(
         }
     }
 }
-
 #[allow(clippy::too_many_arguments)]
 fn serialize_children(
     children: &[JsxChild],
@@ -3001,7 +2972,6 @@ fn serialize_children(
     }
     Ok(child_index)
 }
-
 fn resolve_element_namespace(
     tag: &str,
     parent: Option<DomNamespace>,
@@ -3043,7 +3013,6 @@ fn resolve_element_namespace(
         Some(DomNamespace::Parent) => DomNamespace::Parent,
     }
 }
-
 fn resolve_child_namespace(
     tag: &str,
     element_namespace: DomNamespace,
@@ -3069,14 +3038,12 @@ fn resolve_child_namespace(
     }
     element_namespace
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AnnotationXmlEncoding {
     Html,
     Other,
     Dynamic,
 }
-
 fn annotation_xml_encoding(attributes: &[JsxAttribute]) -> AnnotationXmlEncoding {
     let mut encoding = AnnotationXmlEncoding::Other;
     for attribute in attributes {
@@ -3105,7 +3072,6 @@ fn annotation_xml_encoding(attributes: &[JsxAttribute]) -> AnnotationXmlEncoding
     }
     encoding
 }
-
 fn normalize_attribute_name(tag: &str, name: &str, namespace: DomNamespace) -> String {
     if tag.eq_ignore_ascii_case("annotation-xml") && name.eq_ignore_ascii_case("encoding") {
         return "encoding".to_owned();
@@ -3147,7 +3113,6 @@ fn normalize_attribute_name(tag: &str, name: &str, namespace: DomNamespace) -> S
     }
     .to_owned()
 }
-
 fn is_implicit_table_child(
     parent_tag: Option<&str>,
     parent_namespace: DomNamespace,
@@ -3169,11 +3134,9 @@ fn is_implicit_table_child(
             )
     )
 }
-
 fn renderable_child(child: &JsxChild) -> bool {
     !matches!(child, JsxChild::Text { value, .. } if value.is_empty())
 }
-
 fn is_html_void_element(tag: &str, namespace: DomNamespace) -> bool {
     namespace == DomNamespace::Html
         && matches!(
@@ -3194,7 +3157,6 @@ fn is_html_void_element(tag: &str, namespace: DomNamespace) -> bool {
                 | "wbr"
         )
 }
-
 fn is_standalone_svg_tag(tag: &str) -> bool {
     matches!(
         tag,
@@ -3257,7 +3219,6 @@ fn is_standalone_svg_tag(tag: &str) -> bool {
             | "view"
     )
 }
-
 fn is_standalone_mathml_tag(tag: &str) -> bool {
     matches!(
         tag,
@@ -3300,7 +3261,6 @@ fn is_standalone_mathml_tag(tag: &str) -> bool {
             | "semantics"
     )
 }
-
 fn resolved_element(
     root: EmitTemporaryId,
     path: Vec<u32>,
@@ -3332,7 +3292,6 @@ fn resolved_element(
     resolved.insert(path, target);
     target
 }
-
 fn dom_binding_kind(name: &str) -> DomBindingKind {
     match name {
         "class" | "className" => DomBindingKind::Class,
@@ -3343,7 +3302,6 @@ fn dom_binding_kind(name: &str) -> DomBindingKind {
         _ => DomBindingKind::Attribute(name.to_owned()),
     }
 }
-
 fn create_element_helper(namespace: DomNamespace) -> RuntimeHelper {
     match namespace {
         DomNamespace::Html => RuntimeHelper::CreateElement,
@@ -3354,7 +3312,6 @@ fn create_element_helper(namespace: DomNamespace) -> RuntimeHelper {
         DomNamespace::Parent => RuntimeHelper::CreateElementInParentNamespace,
     }
 }
-
 fn dom_binding_helper(kind: &DomBindingKind, reactive: bool) -> RuntimeHelper {
     match (kind, reactive) {
         (DomBindingKind::Text, true) => RuntimeHelper::BindText,
@@ -3372,7 +3329,6 @@ fn dom_binding_helper(kind: &DomBindingKind, reactive: bool) -> RuntimeHelper {
         (DomBindingKind::Spread, _) => RuntimeHelper::Spread,
     }
 }
-
 fn escape_text(value: &str, output: &mut String) {
     for character in value.chars() {
         match character {
@@ -3383,7 +3339,6 @@ fn escape_text(value: &str, output: &mut String) {
         }
     }
 }
-
 fn escape_attribute(value: &str, output: &mut String) {
     for character in value.chars() {
         match character {
@@ -3395,14 +3350,12 @@ fn escape_attribute(value: &str, output: &mut String) {
         }
     }
 }
-
 fn valid_markup_name(value: &str) -> bool {
     !value.is_empty()
         && value.bytes().all(|byte| {
             byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.' | b'$')
         })
 }
-
 pub fn parse_event_attribute(attribute: &str) -> Option<(String, bool, EventOptions)> {
     let (attribute, resumable_explicit) = match attribute.strip_suffix('$') {
         Some(attribute) => (attribute, true),
@@ -3459,7 +3412,6 @@ pub fn parse_event_attribute(attribute: &str) -> Option<(String, bool, EventOpti
     }
     (!event.is_empty()).then(|| (event.to_ascii_lowercase(), resumable_explicit, options))
 }
-
 fn parse_event_modifier_suffixes(mut suffix: &str) -> Option<EventOptions> {
     let mut options = EventOptions::default();
     while !suffix.is_empty() {
@@ -3477,7 +3429,6 @@ fn parse_event_modifier_suffixes(mut suffix: &str) -> Option<EventOptions> {
     }
     Some(options)
 }
-
 fn creation_helper(kind: FunctionKind, macro_kind: FictMacroKind) -> RuntimeHelper {
     let scoped = matches!(
         kind,
@@ -3491,7 +3442,6 @@ fn creation_helper(kind: FunctionKind, macro_kind: FictMacroKind) -> RuntimeHelp
         (FictMacroKind::Effect, _) => unreachable!("effect has a dedicated helper"),
     }
 }
-
 fn is_runtime_helper_call(
     hir: &HirFile,
     call: &fict_hir::CallInstruction,
@@ -3516,19 +3466,16 @@ fn is_runtime_helper_call(
             .into_iter()
             .any(|family| import.source == spec.module_request(family))
 }
-
 fn function_value(function: &HirFunction, value: ValueId) -> Option<FunctionId> {
     match function.values.get(value.as_usize())?.kind {
         ValueKind::Function(function) => Some(function),
         _ => None,
     }
 }
-
 fn hook_return_accessor_reads(function: &HirFunction) -> BTreeSet<ValueId> {
     if function.kind != FunctionKind::Hook {
         return BTreeSet::new();
     }
-
     let mut visited = BTreeSet::new();
     let mut reads = BTreeSet::new();
     for value in function.blocks.iter().filter_map(|block| {
@@ -3541,7 +3488,6 @@ fn hook_return_accessor_reads(function: &HirFunction) -> BTreeSet<ValueId> {
     }
     reads
 }
-
 fn collect_hook_return_accessor_reads(
     function: &HirFunction,
     value: ValueId,
@@ -3554,7 +3500,6 @@ fn collect_hook_return_accessor_reads(
     let Some(instruction) = function.instruction_for_result(value) else {
         return;
     };
-
     match &instruction.kind {
         HirInstructionKind::Read { .. } | HirInstructionKind::Call(_) => {
             reads.insert(value);
@@ -3597,7 +3542,6 @@ fn collect_hook_return_accessor_reads(
         _ => {}
     }
 }
-
 fn effect_helper(kind: FunctionKind) -> RuntimeHelper {
     if matches!(
         kind,
@@ -3608,7 +3552,6 @@ fn effect_helper(kind: FunctionKind) -> RuntimeHelper {
         RuntimeHelper::Effect
     }
 }
-
 fn place_local(base: PlaceBase) -> Option<LocalId> {
     match base {
         PlaceBase::Local(local) => Some(local),
@@ -3616,7 +3559,6 @@ fn place_local(base: PlaceBase) -> Option<LocalId> {
         PlaceBase::Global(_) | PlaceBase::Value(_) => None,
     }
 }
-
 fn reassigned_locals(function: &HirFunction) -> BTreeSet<LocalId> {
     function
         .blocks
@@ -3636,7 +3578,6 @@ fn reassigned_locals(function: &HirFunction) -> BTreeSet<LocalId> {
         })
         .collect()
 }
-
 fn structured_hook_member_by_binding<'a>(
     function: &HirFunction,
     roots: &'a BTreeMap<BindingId, StructuredHookRootSite>,
@@ -3652,7 +3593,6 @@ fn structured_hook_member_by_binding<'a>(
     let property = root.shape.resolve_property(place.projections.first()?)?;
     Some((local, root, property))
 }
-
 fn imported_reactive_member(
     hir: &HirFile,
     function: &HirFunction,
@@ -3668,7 +3608,6 @@ fn imported_reactive_member(
         .resolve_reactive_member(&place.projections)?;
     Some((local, binding, resolved))
 }
-
 fn imported_hook_direct(
     hir: &HirFile,
     call: &fict_hir::CallInstruction,
@@ -3677,7 +3616,6 @@ fn imported_hook_direct(
     let kind = shape.direct_accessor?;
     Some((binding, kind))
 }
-
 fn imported_hook_return<'a>(
     hir: &'a HirFile,
     call: &fict_hir::CallInstruction,
@@ -3694,7 +3632,6 @@ fn imported_hook_return<'a>(
     };
     Some((binding, shape))
 }
-
 fn imported_hook_member(
     calls: &BTreeMap<ValueId, (BindingId, ImportedHookReturn, Origin)>,
     locals: &BTreeMap<LocalId, ValueId>,
@@ -3718,7 +3655,6 @@ fn imported_hook_member(
     let property = shape.resolve_property(place.projections.first()?)?;
     Some((call, local, *import, property))
 }
-
 fn reject_imported_hook_member_mutation(
     calls: &BTreeMap<ValueId, (BindingId, ImportedHookReturn, Origin)>,
     locals: &BTreeMap<LocalId, ValueId>,
@@ -3729,7 +3665,6 @@ fn reject_imported_hook_member_mutation(
     };
     reject_hook_property_mutation(property, place)
 }
-
 fn reject_captured_hook_member_mutation(
     function: &HirFunction,
     function_id: FunctionId,
@@ -3745,7 +3680,6 @@ fn reject_captured_hook_member_mutation(
     }
     reject_hook_property_mutation(property, place)
 }
-
 fn reject_hook_property_mutation(
     property: ImportedHookPropertyMatch,
     place: &fict_hir::Place,
@@ -3768,7 +3702,6 @@ fn reject_hook_property_mutation(
         }
     }
 }
-
 fn ensure_writable_hook_return(
     slots: &[ReactiveSlot],
     slot: EmitSlotId,
@@ -3785,14 +3718,12 @@ fn ensure_writable_hook_return(
     }
     Ok(())
 }
-
 fn lower_value(value: ValueId, temporaries: &BTreeMap<ValueId, EmitTemporaryId>) -> EmitValueRef {
     temporaries
         .get(&value)
         .copied()
         .map_or(EmitValueRef::Hir(value), EmitValueRef::Temporary)
 }
-
 fn allocate_temporary(
     temporaries: &mut Vec<EmitTemporary>,
     names: &mut NameAllocator,
@@ -3804,7 +3735,6 @@ fn allocate_temporary(
     temporaries.push(EmitTemporary { id, name, origin });
     id
 }
-
 fn preserve(
     operations: &mut Vec<EmitOperation>,
     block: BlockId,
@@ -3817,13 +3747,11 @@ fn preserve(
         origin: hir.origin,
     });
 }
-
 fn reactive_site_origin(function: &HirFunction, result: ValueId) -> Origin {
     function
         .instruction_for_result(result)
         .map_or(function.origin, |instruction| instruction.origin)
 }
-
 fn lower_error(
     code: &'static str,
     message: impl Into<String>,
@@ -3836,21 +3764,17 @@ fn lower_error(
     )
     .with_guarantee_class(guarantee)
 }
-
 fn count_u32(value: usize) -> u32 {
     u32::try_from(value).unwrap_or(u32::MAX)
 }
-
 #[cfg(test)]
 mod namespace_tests {
     use super::*;
     use fict_diagnostics::SourceSpan;
     use fict_hir::{JsxElement, Origin};
-
     fn test_origin() -> Origin {
         Origin::source(SourceSpan::empty(0))
     }
-
     fn element(tag: &str, attributes: Vec<JsxAttribute>, children: Vec<JsxChild>) -> JsxNode {
         JsxNode::Element(JsxElement {
             name: JsxElementName::Intrinsic(tag.to_owned()),
@@ -3859,11 +3783,9 @@ mod namespace_tests {
             origin: test_origin(),
         })
     }
-
     fn node(node: JsxNode) -> JsxChild {
         JsxChild::Node(Box::new(node))
     }
-
     fn spread(value: u32) -> JsxAttribute {
         JsxAttribute::Spread {
             value: ValueId::new(value),
@@ -3871,7 +3793,6 @@ mod namespace_tests {
             origin: test_origin(),
         }
     }
-
     fn expression(value: u32) -> JsxChild {
         JsxChild::Expression {
             value: ValueId::new(value),
@@ -3882,7 +3803,6 @@ mod namespace_tests {
             origin: test_origin(),
         }
     }
-
     #[test]
     fn resolves_svg_integration_points_and_normalizes_attributes() {
         let root = element(
@@ -3948,7 +3868,6 @@ mod namespace_tests {
             ]
         );
     }
-
     #[test]
     fn resolves_mathml_text_annotation_and_runtime_parent_contexts() {
         let root = element(
@@ -4033,7 +3952,6 @@ mod namespace_tests {
             } if *value == ValueId::new(12)
         )));
     }
-
     #[test]
     fn materializes_implicit_table_groups_and_browser_paths() {
         let root = element(
@@ -4069,7 +3987,6 @@ mod namespace_tests {
             .collect();
         assert_eq!(paths, [vec![0, 0], vec![1, 0, 0], vec![1, 1, 0]]);
     }
-
     #[test]
     fn rejects_static_children_when_annotation_namespace_is_runtime_selected() {
         let root = element(
@@ -4089,7 +4006,6 @@ mod namespace_tests {
                 .any(|diagnostic| diagnostic.code.as_str() == "FICT-EMIT-NAMESPACE-DYNAMIC")
         );
     }
-
     #[test]
     fn classifies_standalone_foreign_roots_and_rejects_void_children() {
         assert_eq!(
@@ -4120,7 +4036,6 @@ mod namespace_tests {
                 .any(|diagnostic| diagnostic.code.as_str() == "FICT-EMIT-VOID-CHILD")
         );
     }
-
     #[test]
     fn preserves_explicit_resumable_event_intent_without_polluting_the_dom_event_name() {
         let root = element(
@@ -4171,7 +4086,6 @@ mod namespace_tests {
             .collect();
         assert_eq!(events, [("click", true), ("input", true), ("blur", false)]);
     }
-
     #[test]
     fn normalizes_dom_event_options_and_pointer_capture_names() {
         let (event, explicit, options) =

--- a/crates/fict-emit/src/verify.rs
+++ b/crates/fict-emit/src/verify.rs
@@ -862,6 +862,11 @@ fn verify_operations(
                 slot,
                 source_result,
                 ..
+            }
+            | EmitOperation::CreateDerived {
+                slot,
+                source_result,
+                ..
             } => {
                 verify_slot(function, *slot, diagnostics);
                 verify_source_result(hir_function, *source_result, diagnostics);
@@ -1439,6 +1444,15 @@ fn verify_helper_semantics(
                         | crate::ReactiveSlotKind::Store
                         | crate::ReactiveSlotKind::Resource => false,
                     }
+            })
+        }
+        EmitOperation::CreateDerived { slot, helper, .. } => {
+            function.slots.get(slot.as_usize()).is_some_and(|slot| {
+                slot.storage == crate::ReactiveSlotStorage::Owned
+                    && slot.kind == crate::ReactiveSlotKind::Memo
+                    && helper.is_none_or(|helper| {
+                        matches!(helper, RuntimeHelper::Memo | RuntimeHelper::UseMemo)
+                    })
             })
         }
         EmitOperation::RegisterEffect { helper, .. } => {

--- a/crates/fict-emit/src/verify.rs
+++ b/crates/fict-emit/src/verify.rs
@@ -1,17 +1,14 @@
-use std::collections::BTreeSet;
-
+use crate::{
+    CleanupOwner, DomNamespace, EmitOperation, EmitProgram, EmitValueRef, RuntimeHelper,
+    RuntimeHelperStability, verify_runtime_abi,
+};
 use fict_diagnostics::{
     Diagnostic, DiagnosticBundle, DiagnosticCode, DiagnosticSeverity, GuaranteeClass,
 };
 use fict_hir::HirFile;
 use fict_reactivity::RegionAnalysis;
 use fict_reactivity::{analyze_cfg, verify_structurized_cfg};
-
-use crate::{
-    CleanupOwner, DomNamespace, EmitOperation, EmitProgram, EmitValueRef, RuntimeHelper,
-    RuntimeHelperStability, verify_runtime_abi,
-};
-
+use std::collections::BTreeSet;
 /// Verify EmitIR helper, slot/temp, region/template, cleanup, and rejection invariants.
 pub fn verify_emit_program(
     hir: &HirFile,
@@ -466,7 +463,6 @@ pub fn verify_emit_program(
         Err(diagnostics)
     }
 }
-
 fn verify_imports(program: &EmitProgram, diagnostics: &mut DiagnosticBundle) {
     let used: BTreeSet<_> = program
         .functions
@@ -537,7 +533,6 @@ fn verify_imports(program: &EmitProgram, diagnostics: &mut DiagnosticBundle) {
         ));
     }
 }
-
 fn verify_preview_plan(hir: &HirFile, program: &EmitProgram, diagnostics: &mut DiagnosticBundle) {
     let Some(preview) = &program.preview_plan else {
         return;
@@ -637,7 +632,6 @@ fn verify_preview_plan(hir: &HirFile, program: &EmitProgram, diagnostics: &mut D
         }
     }
 }
-
 fn preview_binding_has_runtime_write(hir: &HirFile, binding: fict_hir::BindingId) -> bool {
     hir.functions.iter().any(|function| {
         function
@@ -671,7 +665,6 @@ fn preview_binding_has_runtime_write(hir: &HirFile, binding: fict_hir::BindingId
             })
     })
 }
-
 fn preview_place_binding(
     function: &fict_hir::HirFunction,
     place: &fict_hir::Place,
@@ -683,7 +676,6 @@ fn preview_place_binding(
     };
     function.locals.get(local.as_usize())?.binding
 }
-
 fn verify_module_plan(hir: &HirFile, program: &EmitProgram, diagnostics: &mut DiagnosticBundle) {
     if program
         .module
@@ -787,14 +779,12 @@ fn verify_module_plan(hir: &HirFile, program: &EmitProgram, diagnostics: &mut Di
         ));
     }
 }
-
 fn is_scoped_helper(helper: RuntimeHelper) -> bool {
     matches!(
         helper,
         RuntimeHelper::UseSignal | RuntimeHelper::UseMemo | RuntimeHelper::UseEffect
     )
 }
-
 fn verify_operations(
     hir: &HirFile,
     hir_function: &fict_hir::HirFunction,
@@ -1159,7 +1149,6 @@ fn verify_operations(
         }
     }
 }
-
 fn verify_source_result(
     function: &fict_hir::HirFunction,
     value: fict_hir::ValueId,
@@ -1172,7 +1161,6 @@ fn verify_source_result(
         ));
     }
 }
-
 fn hook_call_instruction(
     function: &fict_hir::HirFunction,
     value: fict_hir::ValueId,
@@ -1187,7 +1175,6 @@ fn hook_call_instruction(
             _ => None,
         })
 }
-
 fn imported_hook_return_shape<'a>(
     hir: &'a HirFile,
     call: &fict_hir::CallInstruction,
@@ -1567,6 +1554,16 @@ fn verify_helper_semantics(
                         *create_helper == RuntimeHelper::CreateElementInParentNamespace
                     }
                 }
+        }
+        EmitOperation::ConditionalReturn {
+            helper,
+            create_helper,
+            cleanup_helper,
+            ..
+        } => {
+            *helper == RuntimeHelper::Conditional
+                && *create_helper == RuntimeHelper::CreateElement
+                && *cleanup_helper == RuntimeHelper::OnDestroy
         }
         EmitOperation::KeyedChild {
             helper,

--- a/crates/fict-emit/tests/emit_ir.rs
+++ b/crates/fict-emit/tests/emit_ir.rs
@@ -132,6 +132,7 @@ fn program() -> EmitProgram {
                     slot: EmitSlotId::new(0),
                     source_result: fict_hir::ValueId::new(0),
                     local: None,
+                    name: None,
                     initializer: Some(EmitValueRef::Literal(LiteralValue::Undefined)),
                     helper: RuntimeHelper::Signal,
                     origin: origin(),

--- a/crates/fict-emit/tests/lower_no_jsx.rs
+++ b/crates/fict-emit/tests/lower_no_jsx.rs
@@ -1,6 +1,7 @@
 use fict_emit::{
     CleanupOwner, DomNamespace, EmitOperation, NoJsxLoweringOptions, ReactiveSlotKind,
-    RuntimeFamily, RuntimeHelper, lower_core, lower_no_jsx,
+    RuntimeFamily, RuntimeHelper, lower_core as lower_core_with_scopes,
+    lower_no_jsx as lower_no_jsx_with_scopes,
 };
 use fict_hir::{
     Binding, BindingId, BindingKind, BlockId, CallArgument, CallHost, CallInstruction,
@@ -17,6 +18,11 @@ use fict_reactivity::{
     ReactiveCycleAnalysis, RegionAnalysis, analyze_aliases, analyze_dependencies,
     analyze_reactive_cycles, analyze_reactive_scopes, analyze_regions, analyze_shapes, analyze_ssa,
 };
+
+#[rustfmt::skip]
+macro_rules! lower_no_jsx { ($hir:expr, $regions:expr, $cycles:expr, $options:expr $(,)?) => { lower_no_jsx_with_scopes($hir, $regions, $cycles, None, $options) }; }
+#[rustfmt::skip]
+macro_rules! lower_core { ($hir:expr, $regions:expr, $cycles:expr, $options:expr $(,)?) => { lower_core_with_scopes($hir, $regions, $cycles, None, $options) }; }
 
 fn origin() -> Origin {
     Origin::source(SourceSpan::empty(0))
@@ -239,7 +245,7 @@ fn lowers_module_state_reads_writes_updates_and_effects() {
     let hir = fixture(FunctionKind::Module);
     verify_hir(&hir).expect("valid lowering fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_no_jsx(
+    let program = lower_no_jsx!(
         &hir,
         &regions,
         &cycles,
@@ -358,7 +364,7 @@ fn lowers_reactive_targets_inside_assignment_patterns() {
 
     verify_hir(&hir).expect("valid reactive pattern lowering fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_no_jsx(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_no_jsx!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("reactive pattern lowering");
     let operation = program.functions[0]
         .operations
@@ -387,7 +393,7 @@ fn lowers_reactive_targets_inside_assignment_patterns() {
 fn selects_hook_context_helpers_inside_components() {
     let hir = fixture(FunctionKind::Component);
     let (regions, cycles) = analyses(&hir);
-    let program = lower_no_jsx(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_no_jsx!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("component lowering");
     assert!(
         program
@@ -525,7 +531,7 @@ fn lowers_intrinsic_templates_with_escaping_paths_and_static_bindings() {
     }];
     verify_hir(&hir).expect("valid JSX fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_core(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_core!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("intrinsic JSX lowering");
     let declare = program.functions[0]
         .operations
@@ -631,7 +637,7 @@ fn lowers_intrinsic_templates_with_escaping_paths_and_static_bindings() {
     assert!(!declare.0.contains("onClick"));
     assert!(!declare.0.contains(" ref"));
 
-    let vnode = lower_core(
+    let vnode = lower_core!(
         &hir,
         &regions,
         &cycles,
@@ -665,7 +671,7 @@ fn lowers_intrinsic_templates_with_escaping_paths_and_static_bindings() {
             .any(|operation| { matches!(operation, EmitOperation::DeclareTemplate { .. }) })
     );
 
-    let diagnostics = lower_no_jsx(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let diagnostics = lower_no_jsx!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect_err("no-JSX phase rejects JSX");
     assert!(
         diagnostics
@@ -687,7 +693,7 @@ fn lowers_intrinsic_templates_with_escaping_paths_and_static_bindings() {
         })));
     hir.templates[0].contains_fragment = true;
     verify_hir(&hir).expect("valid nested fragment fixture");
-    let fragment_vnode = lower_core(
+    let fragment_vnode = lower_core!(
         &hir,
         &regions,
         &cycles,
@@ -787,7 +793,7 @@ fn lowers_binding_aware_component_props_spreads_and_children_in_source_order() {
     }];
     verify_hir(&hir).expect("valid component JSX fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_core(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_core!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("component JSX lowering");
     let operation = program.functions[0]
         .operations
@@ -840,7 +846,7 @@ fn carries_structured_conditional_plan_into_emit_function() {
     }
     verify_hir(&hir).expect("valid conditional fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_core(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_core!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("conditional lowering");
     assert!(
         program.functions[0]
@@ -948,7 +954,7 @@ fn lowers_only_binding_aware_runtime_keyed_list_calls() {
     verify_hir(&hir).expect("valid keyed-list fixture");
 
     let (regions, cycles) = analyses(&hir);
-    let program = lower_core(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_core!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("keyed-list lowering");
     assert!(
         program
@@ -972,7 +978,7 @@ fn lowers_only_binding_aware_runtime_keyed_list_calls() {
 
     hir.bindings[0].import.as_mut().expect("import").source = "third-party/list".into();
     let (regions, cycles) = analyses(&hir);
-    let spoofed = lower_core(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let spoofed = lower_core!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("same-named third-party helper remains ordinary HIR");
     assert!(
         !spoofed
@@ -1097,7 +1103,7 @@ fn tracks_preserved_store_resource_and_selector_calls() {
     };
     verify_hir(&hir).expect("valid runtime reactive fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_no_jsx(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
+    let program = lower_no_jsx!(&hir, &regions, &cycles, NoJsxLoweringOptions::default())
         .expect("runtime reactive tracking");
     assert_eq!(
         program.functions[0]
@@ -1171,7 +1177,7 @@ fn allocates_collision_free_module_helpers_and_temporaries() {
     ));
     verify_hir(&hir).expect("valid collision fixture");
     let (regions, cycles) = analyses(&hir);
-    let program = lower_no_jsx(
+    let program = lower_no_jsx!(
         &hir,
         &regions,
         &cycles,

--- a/crates/fict-hir/src/ir.rs
+++ b/crates/fict-hir/src/ir.rs
@@ -1409,6 +1409,16 @@ pub struct HirFunction {
     pub origin: Origin,
 }
 
+impl HirFunction {
+    /// Find the instruction that defines one function-local value.
+    pub fn instruction_for_result(&self, result: ValueId) -> Option<&HirInstruction> {
+        self.blocks
+            .iter()
+            .flat_map(|block| &block.instructions)
+            .find(|instruction| instruction.result == Some(result))
+    }
+}
+
 /// Complete OXC-independent HIR for one source file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HirFile {

--- a/crates/fict-hir/src/jsx.rs
+++ b/crates/fict-hir/src/jsx.rs
@@ -1,4 +1,6 @@
-use crate::{BindingId, FunctionId, Origin, TemplateId, ValueId};
+use std::collections::BTreeSet;
+
+use crate::{BindingId, FunctionId, HirFile, Origin, TemplateId, ValueId};
 
 /// JSX tag identity after semantic binding resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,6 +210,15 @@ pub enum JsxNode {
 }
 
 impl JsxNode {
+    /// Return this node's source provenance.
+    #[must_use]
+    pub const fn origin(&self) -> Origin {
+        match self {
+            Self::Element(element) => element.origin,
+            Self::Fragment { origin, .. } => *origin,
+        }
+    }
+
     /// Whether this tree contains source short-fragment syntax and therefore needs the runtime
     /// `Fragment` identity when emitted as a VNode.
     #[must_use]
@@ -233,6 +244,60 @@ pub struct JsxTemplate {
     pub contains_fragment: bool,
     /// Source provenance for the complete template.
     pub origin: Origin,
+}
+
+impl HirFile {
+    /// Collect semantic bindings used as the item parameter of JSX list callbacks.
+    #[must_use]
+    pub fn jsx_list_item_bindings(&self) -> BTreeSet<BindingId> {
+        enum Item<'a> {
+            Node(&'a JsxNode),
+            Child(&'a JsxChild),
+        }
+
+        let mut bindings = BTreeSet::new();
+        for template in &self.templates {
+            let mut stack = vec![Item::Node(&template.root)];
+            while let Some(item) = stack.pop() {
+                match item {
+                    Item::Node(JsxNode::Element(element)) => {
+                        for attribute in &element.attributes {
+                            if let JsxAttribute::Named {
+                                value: JsxAttributeValue::Node(node),
+                                ..
+                            } = attribute
+                            {
+                                stack.push(Item::Node(node));
+                            }
+                        }
+                        stack.extend(element.children.iter().map(Item::Child));
+                    }
+                    Item::Node(JsxNode::Fragment { children, .. }) => {
+                        stack.extend(children.iter().map(Item::Child));
+                    }
+                    Item::Child(JsxChild::Expression {
+                        list: Some(list), ..
+                    }) => {
+                        if let Some(binding) = self
+                            .functions
+                            .get(list.callback.as_usize())
+                            .and_then(|function| function.parameters.first())
+                            .and_then(|parameter| parameter.binding)
+                        {
+                            bindings.insert(binding);
+                        }
+                    }
+                    Item::Child(JsxChild::Node(node)) => stack.push(Item::Node(node)),
+                    Item::Child(
+                        JsxChild::Text { .. }
+                        | JsxChild::Expression { .. }
+                        | JsxChild::Spread { .. },
+                    ) => {}
+                }
+            }
+        }
+        bindings
+    }
 }
 
 #[cfg(test)]

--- a/crates/fict-reactivity/src/effects.rs
+++ b/crates/fict-reactivity/src/effects.rs
@@ -337,6 +337,7 @@ pub fn analyze_dependencies(
                             ) {
                                 direct_dependencies[result_index].insert(path);
                             }
+                            input_edges[result_index].extend(projection_values(place));
                         }
                         HirInstructionKind::Delete {
                             target: DeleteTarget::Place(place),

--- a/crates/fict-reactivity/src/scopes.rs
+++ b/crates/fict-reactivity/src/scopes.rs
@@ -160,6 +160,16 @@ pub fn analyze_reactive_scopes(
             ShapeSource::Alias(_) if shape.kind == ShapeKind::Reactive => {
                 Some(ReactiveBindingKind::Alias)
             }
+            ShapeSource::Parameter
+                if function.kind == fict_hir::FunctionKind::Component
+                    && function.binding.is_some_and(|binding| {
+                        file.bindings[binding.as_usize()]
+                            .display_name
+                            .starts_with(char::is_uppercase)
+                    }) =>
+            {
+                Some(ReactiveBindingKind::Alias)
+            }
             ShapeSource::Entry
             | ShapeSource::Parameter
             | ShapeSource::Literal(_)

--- a/docs/features/rust-compiler-rollout/rollout.md
+++ b/docs/features/rust-compiler-rollout/rollout.md
@@ -31,9 +31,9 @@ v3 records the candidate, full native-certification, rollout-review, and
 legacy-removal-review paths plus the Rust-default, completed
 compatibility-minor, final legacy, and planned legacy-removal releases; beta
 keeps all four version values `null`. Evidence and review paths must remain
-workspace-relative. The normal beta readiness check validates both pending
-review documents, so an unknown area, non-boolean value, or partial approval
-fails before promotion work starts.
+workspace-relative. Readiness validates both review document shapes in every
+phase, so an unknown area, non-boolean value, or partial approval fails before
+promotion work starts.
 The same check binds the compiler package root to the phase: beta MUST retain
 the legacy facade, while `rust-default` and `legacy-removal` MUST expose the
 complete native request API without importing the legacy implementation.
@@ -93,8 +93,8 @@ compatibility, and a compiler root that does not expose the Rust
 
 | Mode     | Purpose                                        | Delivered output | Allowed use                                   |
 | -------- | ---------------------------------------------- | ---------------- | --------------------------------------------- |
-| `legacy` | Compatibility and whole-build rollback         | Babel/TypeScript | Supported during the bounded window           |
-| `rust`   | Native beta and eventual Core default          | OXC/Rust         | Explicit application/CI opt-in during beta    |
+| `legacy` | Compatibility and whole-build rollback         | Babel/TypeScript | Explicit recovery during the bounded window   |
+| `rust`   | Native Core compiler                           | OXC/Rust         | Core default; may also be selected explicitly |
 | `shadow` | Compare native behavior without changing build | Legacy           | CI or an explicit local diagnostic build only |
 
 One build MUST use one mode. A transform failure MUST NOT select another
@@ -182,7 +182,8 @@ hand-maintained benchmark or package-size claim.
 
 The checked-in
 [`compiler-rollout-review.json`](../../../.github/compiler-rollout-review.json)
-is intentionally pending until a maintainer reviews a two-candidate artifact.
+begins pending and may become approved only after a maintainer reviews a
+two-candidate artifact.
 The same candidate source revision MUST also complete the Release workflow's
 8-target × 2-Node certification; its retained JSON is copied to the
 `nativeCertificationPath` declared by rollout state. Approval MUST bind both
@@ -225,9 +226,9 @@ pnpm release:compiler:rust-rollout
 pnpm release:verify:clean
 ```
 
-The first command validates phase consistency. The second produces current
-Rust evidence. Only the clean detached release gate can count for publishing.
-Human approval remains required before changing the state to `rust-default`.
+The first command validates phase consistency and the digest-bound human
+approval. The second produces current Rust evidence. Only the clean detached
+release gate can count for publishing.
 
 ## Related decisions
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -19,21 +19,22 @@ profile. Production builds force strict guarantee back on.
 
 ## Compiler Backend Migration
 
-The OXC-native compiler is available as an explicit beta while Vite keeps the
-legacy backend as its default. Select one backend for the entire build:
+The OXC-native compiler is the Vite/Core default starting with the planned
+0.29.0 release. A build still selects exactly one backend:
 
 ```ts
 import fict from '@fictjs/vite-plugin'
 
 export default {
-  plugins: [fict({ backend: 'rust' })],
+  plugins: [fict()],
 }
 ```
 
-Use `FICT_COMPILER_BACKEND=rust` for an application-wide CI trial and
-`FICT_COMPILER_BACKEND=legacy` for operational rollback. An explicit plugin
-option takes precedence over the environment. Do not choose the backend from a
-per-file callback or retry a failed Rust file through Babel.
+Use `FICT_COMPILER_BACKEND=legacy` for operational rollback. An explicit plugin
+option takes precedence over the environment, so `backend: 'legacy'` can pin a
+committed recovery build while `backend: 'rust'` can pin the normal default.
+Do not choose the backend from a per-file callback or retry a failed Rust file
+through Babel.
 
 With `backend: 'rust'`, the Vite runtime graph uses the native compiler and the
 Babel-free compiler graph host. Babel packages can remain installed during the
@@ -62,9 +63,10 @@ structural; diagnostics, metadata, semantic events, maps, and artifacts remain
 blocking.
 
 Webpack users should migrate from `@fictjs/babel-preset` to the native
-`@fictjs/webpack-plugin` loader. Direct compiler integrations can import the
-serializable `transformSync`, `transform`, `scan`, or `analyze` facade from
-`@fictjs/compiler/native`; the facade lazily selects and reuses the validated
+`@fictjs/webpack-plugin` loader. Direct compiler integrations import the
+serializable `transformSync`, `transform`, `scan`, or `analyze` API from
+`@fictjs/compiler`; the lower-level loader remains available from
+`@fictjs/compiler/native`. Both facades lazily select and reuse the validated
 platform binding. Custom Babel pipelines that still
 need sibling plugins should run native Fict compilation as a separate first
 stage and compose source maps explicitly.
@@ -74,7 +76,7 @@ compatibility window, but emits one development-time deprecation warning per
 process. Do not suppress that warning in committed configuration; migrate to an
 official Vite, Webpack, or direct native integration.
 
-Preview `resumable: true` is available with the Rust beta through compiler-owned
+Preview `resumable: true` is available with the Rust compiler through compiler-owned
 structured handler artifacts. It remains explicit and Preview; native support
 does not graduate it or make it a Core default.
 

--- a/packages/babel-preset/src/index.ts
+++ b/packages/babel-preset/src/index.ts
@@ -21,15 +21,17 @@ import syntaxTypeScript from '@babel/plugin-syntax-typescript'
 import transformModulesCommonJS from '@babel/plugin-transform-modules-commonjs'
 import transformTypeScript from '@babel/plugin-transform-typescript'
 import {
-  DiagnosticCode,
   invalidateModuleMetadata,
   resolveModuleMetadata as resolveCompilerModuleMetadata,
   setModuleMetadata,
+} from '@fictjs/compiler/graph-host'
+import {
+  DiagnosticCode,
+  createFictPlugin,
   type CompilerWarning,
   type FictCompilerOptions,
   type ModuleReactiveMetadata,
-} from '@fictjs/compiler'
-import { createFictPlugin } from '@fictjs/compiler/legacy'
+} from '@fictjs/compiler/legacy'
 
 declare module '@babel/core' {
   interface BabelFileMetadata {
@@ -1728,5 +1730,5 @@ export default function fictPreset(
   }
 }
 
-export type { FictCompilerOptions } from '@fictjs/compiler'
+export type { FictCompilerOptions } from '@fictjs/compiler/legacy'
 export { createFictPlugin } from '@fictjs/compiler/legacy'

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -5,15 +5,8 @@
  * Babel-based compiler remains available only through `@fictjs/compiler/legacy` during the
  * compatibility window.
  */
-export {
-  nativeCompilerInfo,
-  transformSync,
-  transform,
-  scanSync,
-  scan,
-  analyzeSync,
-  analyze,
-} from './native-loader'
+export { nativeCompilerInfo, transformSync, transform, scanSync } from './native-loader'
+export { scan, analyzeSync, analyze } from './native-loader'
 export type { NativeCompilerInfo } from './native-loader'
 export { COMPILER_PROTOCOL_VERSION, MODULE_REACTIVE_METADATA_VERSION } from './types'
 export type * from './types'

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,9 +1,20 @@
 /**
- * Package-root compatibility facade for the beta rollout.
+ * OXC/Rust compiler package root.
  *
- * The root deliberately preserves the Babel plugin API until M7 promotion is authorized. The
- * implementation lives behind a legacy-owned module so a later Rust-default root can replace this
- * facade without making `@fictjs/compiler/legacy` depend on, or cycle through, the new root.
+ * The package root exposes the serializable native request API after M7 promotion. The
+ * Babel-based compiler remains available only through `@fictjs/compiler/legacy` during the
+ * compatibility window.
  */
-export { createFictPlugin as default } from './legacy-compiler'
-export * from './legacy-compiler'
+export {
+  nativeCompilerInfo,
+  transformSync,
+  transform,
+  scanSync,
+  scan,
+  analyzeSync,
+  analyze,
+} from './native-loader'
+export type { NativeCompilerInfo } from './native-loader'
+export { COMPILER_PROTOCOL_VERSION, MODULE_REACTIVE_METADATA_VERSION } from './types'
+export type * from './types'
+export type * from './tooling/types'

--- a/packages/compiler/src/legacy.ts
+++ b/packages/compiler/src/legacy.ts
@@ -1,10 +1,9 @@
 /**
  * Explicit compatibility entrypoint for the Babel-based compiler.
  *
- * The package root remains an equivalent facade during the beta window, but this entrypoint owns a
- * direct implementation edge. Integrations that intentionally use the rollback compiler import
- * this subpath so the eventual Rust-default root change cannot be mistaken for an implicit Babel
- * dependency.
+ * This entrypoint owns the complete compatibility API after the package root switches to Rust.
+ * Integrations that intentionally use the rollback compiler import this subpath so the native root
+ * cannot be mistaken for an implicit Babel dependency.
  */
-export { default, createFictPlugin, getCompilerCacheFingerprint } from './legacy-compiler'
-export type { FictCompilerOptions } from './types'
+export { default } from './legacy-compiler'
+export * from './legacy-compiler'

--- a/packages/compiler/src/native-loader.ts
+++ b/packages/compiler/src/native-loader.ts
@@ -259,10 +259,5 @@ export function createNativeCompilerFacade(options?: NativeLoaderOptions): Nativ
 const defaultNativeCompiler = createNativeCompilerFacade()
 
 /** Direct OXC/Rust request functions. No function retries through the legacy compiler. */
-export const nativeCompilerInfo = defaultNativeCompiler.nativeCompilerInfo
-export const transformSync = defaultNativeCompiler.transformSync
-export const transform = defaultNativeCompiler.transform
-export const scanSync = defaultNativeCompiler.scanSync
-export const scan = defaultNativeCompiler.scan
-export const analyzeSync = defaultNativeCompiler.analyzeSync
-export const analyze = defaultNativeCompiler.analyze
+export const { nativeCompilerInfo, transformSync, transform, scanSync } = defaultNativeCompiler
+export const { scan, analyzeSync, analyze } = defaultNativeCompiler

--- a/packages/compiler/test/cache-fingerprint.test.ts
+++ b/packages/compiler/test/cache-fingerprint.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 
-import { getCompilerCacheFingerprint } from '@fictjs/compiler'
+import { getCompilerCacheFingerprint } from '@fictjs/compiler/legacy'
 import { describe, expect, it } from 'vitest'
 
 import { readLoadedCompilerArtifact } from '../src/cache-fingerprint'

--- a/packages/compiler/test/cross-module.test.ts
+++ b/packages/compiler/test/cross-module.test.ts
@@ -2,11 +2,8 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import {
-  clearModuleMetadata,
-  MODULE_REACTIVE_METADATA_VERSION,
-  type FictCompilerOptions,
-} from '../src/index'
+import { clearModuleMetadata } from '../src/graph-host'
+import { MODULE_REACTIVE_METADATA_VERSION, type FictCompilerOptions } from '../src/index'
 import { transform } from './test-utils'
 
 describe('Cross-Module Reactivity', () => {

--- a/packages/compiler/test/explain-artifact.test.ts
+++ b/packages/compiler/test/explain-artifact.test.ts
@@ -1,7 +1,7 @@
 import { transformSync } from '@babel/core'
 import { describe, expect, it } from 'vitest'
 
-import createFictPlugin, { type CompilerExplainArtifact } from '../src'
+import createFictPlugin, { type CompilerExplainArtifact } from '../src/legacy'
 
 import { transform } from './test-utils'
 

--- a/packages/compiler/test/fixtures/api-type-contract.ts
+++ b/packages/compiler/test/fixtures/api-type-contract.ts
@@ -5,7 +5,7 @@ import {
   type FictCompilerOptions,
   type SourceMinimizerOptions,
   type SourceMinimizerResult,
-} from '../../src'
+} from '../../src/legacy'
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false

--- a/packages/compiler/test/metadata-protocol.test.ts
+++ b/packages/compiler/test/metadata-protocol.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import { parseModuleReactiveMetadata } from '../src/graph-host'
 import {
   MODULE_REACTIVE_METADATA_VERSION,
-  parseModuleReactiveMetadata,
   type ReactiveExportKind,
   type ResolvedMetadataInput,
 } from '../src/index'

--- a/packages/compiler/test/module-metadata-safety.test.ts
+++ b/packages/compiler/test/module-metadata-safety.test.ts
@@ -15,13 +15,13 @@ import { transformSync } from '@babel/core'
 import syntaxJsx from '@babel/plugin-syntax-jsx'
 import { describe, expect, it } from 'vitest'
 
-import createFictPlugin, { type CompilerWarning } from '../src'
+import createFictPlugin, { type CompilerWarning } from '../src/legacy'
 import {
   clearModuleMetadata,
   invalidateModuleMetadata,
   resolveModuleMetadata,
   setModuleMetadata,
-} from '../src'
+} from '../src/graph-host'
 import type { ModuleReactiveMetadata } from '../src/types'
 
 describe('module metadata safety', () => {

--- a/packages/compiler/test/native-loader.test.ts
+++ b/packages/compiler/test/native-loader.test.ts
@@ -30,10 +30,6 @@ import legacyCompiler, {
   createFictPlugin as explicitLegacyCompiler,
   getCompilerCacheFingerprint as getLegacyCompilerCacheFingerprint,
 } from '../src/legacy'
-import rootCompiler, {
-  createFictPlugin as rootLegacyCompiler,
-  getCompilerCacheFingerprint as getRootCompilerCacheFingerprint,
-} from '../src/index'
 
 function createCompileResult(): CompileResult {
   return {
@@ -94,10 +90,9 @@ function createBinding(): NativeCompilerBinding {
 }
 
 describe('native compiler loader', () => {
-  it('keeps the explicit legacy entrypoint identical during the beta window', () => {
-    expect(legacyCompiler).toBe(rootCompiler)
-    expect(explicitLegacyCompiler).toBe(rootLegacyCompiler)
-    expect(getLegacyCompilerCacheFingerprint).toBe(getRootCompilerCacheFingerprint)
+  it('keeps the explicit legacy entrypoint available during the compatibility window', () => {
+    expect(legacyCompiler).toBe(explicitLegacyCompiler)
+    expect(typeof getLegacyCompilerCacheFingerprint).toBe('function')
   })
 
   it('exports the complete serializable direct compiler facade', () => {

--- a/packages/compiler/test/native-root.test.ts
+++ b/packages/compiler/test/native-root.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import * as compiler from '../src'
+import * as native from '../src/native-loader'
+
+describe('@fictjs/compiler Rust-default root', () => {
+  it('exposes the native request API without the legacy Babel plugin', () => {
+    expect(compiler.nativeCompilerInfo).toBe(native.nativeCompilerInfo)
+    expect(compiler.transformSync).toBe(native.transformSync)
+    expect(compiler.transform).toBe(native.transform)
+    expect(compiler.scanSync).toBe(native.scanSync)
+    expect(compiler.scan).toBe(native.scan)
+    expect(compiler.analyzeSync).toBe(native.analyzeSync)
+    expect(compiler.analyze).toBe(native.analyze)
+    expect(compiler).not.toHaveProperty('createFictPlugin')
+    expect(compiler).not.toHaveProperty('default')
+  })
+})

--- a/packages/compiler/test/semantic-validation.test.ts
+++ b/packages/compiler/test/semantic-validation.test.ts
@@ -2,7 +2,7 @@ import { transformSync } from '@babel/core'
 import syntaxJsx from '@babel/plugin-syntax-jsx'
 import { describe, expect, it } from 'vitest'
 
-import createFictPlugin from '../src'
+import createFictPlugin from '../src/legacy'
 import { transform } from './test-utils'
 
 describe('semantic validation', () => {

--- a/packages/compiler/test/sourcemap.test.ts
+++ b/packages/compiler/test/sourcemap.test.ts
@@ -3,7 +3,7 @@ import pluginTransformTypescript from '@babel/plugin-transform-typescript'
 import { TraceMap, originalPositionFor, type SourceMapInput } from '@jridgewell/trace-mapping'
 import { describe, expect, it } from 'vitest'
 
-import createFictPlugin from '../src/index'
+import createFictPlugin from '../src/legacy'
 
 // ============================================================================
 // Helper Functions

--- a/packages/compiler/test/test-utils.ts
+++ b/packages/compiler/test/test-utils.ts
@@ -2,7 +2,7 @@ import { transformSync, type PluginItem } from '@babel/core'
 import pluginTransformCjs from '@babel/plugin-transform-modules-commonjs'
 import pluginTransformTypescript from '@babel/plugin-transform-typescript'
 
-import createFictPlugin, { type FictCompilerOptions } from '../src/index'
+import createFictPlugin, { type FictCompilerOptions } from '../src/legacy'
 
 export function runLegacyTransform(
   source: string,

--- a/packages/compiler/test/tooling-analyze.test.ts
+++ b/packages/compiler/test/tooling-analyze.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { analyzeFictFile } from '../src/index'
+import { analyzeFictFile } from '../src/legacy'
 import { inferCompilerDiagnosticFromSource } from '../src/tooling/analyze'
 
 const SAMPLE_COMPONENT = `

--- a/packages/compiler/test/tooling-export-surface.test.ts
+++ b/packages/compiler/test/tooling-export-surface.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import * as compiler from '../src/index'
+import * as compiler from '../src/legacy'
 
-describe('compiler tooling export surface', () => {
-  it('exports analyze and trace helpers from compiler root', () => {
+describe('legacy compiler tooling export surface', () => {
+  it('exports analyze and trace helpers from the compatibility entrypoint', () => {
     expect(typeof compiler.analyzeFictFile).toBe('function')
     expect(typeof compiler.inferTraceMarkersForComponent).toBe('function')
     expect(typeof compiler.minimizeSourceByLines).toBe('function')

--- a/packages/compiler/test/tooling-minimize.test.ts
+++ b/packages/compiler/test/tooling-minimize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { minimizeSourceByLines } from '../src'
+import { minimizeSourceByLines } from '../src/legacy'
 
 describe('source regression minimizer', () => {
   it.each(['rust', 'legacy'] as const)(

--- a/packages/compiler/test/using-declaration.test.ts
+++ b/packages/compiler/test/using-declaration.test.ts
@@ -2,7 +2,7 @@ import { transformSync } from '@babel/core'
 import pluginTransformTypescript from '@babel/plugin-transform-typescript'
 import { describe, expect, it } from 'vitest'
 
-import createFictPlugin from '../src/index'
+import createFictPlugin from '../src/legacy'
 
 function transformWithExplicitResourceManagement(source: string): void {
   transformSync(source, {

--- a/packages/router/test/context-isolation.test.tsx
+++ b/packages/router/test/context-isolation.test.tsx
@@ -53,6 +53,12 @@ function SsrLocationProbe() {
   return <span>{location().pathname}</span>
 }
 
+function ssrTextContent(html: string): string | null {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  return template.content.textContent
+}
+
 describe('router context isolation', () => {
   it('keeps independent DOM roots bound to their own router and guard context', async () => {
     const firstHistory = createMemoryHistory({ initialEntries: ['/first'] })
@@ -202,15 +208,15 @@ describe('router context isolation', () => {
     try {
       expect(firstRequest.html).toContain('/ssr-first')
       expect(secondRequest.html).toContain('/ssr-second')
-      expect(renderToString(() => <SsrLocationProbe />, { includeSnapshot: false })).toContain(
-        '<!--fict:slot:start-->/<!--fict:slot:end-->',
-      )
+      expect(
+        ssrTextContent(renderToString(() => <SsrLocationProbe />, { includeSnapshot: false })),
+      ).toBe('/')
 
       secondRequest.dispose()
       secondDisposed = true
-      expect(renderToString(() => <SsrLocationProbe />, { includeSnapshot: false })).toContain(
-        '<!--fict:slot:start-->/<!--fict:slot:end-->',
-      )
+      expect(
+        ssrTextContent(renderToString(() => <SsrLocationProbe />, { includeSnapshot: false })),
+      ).toBe('/')
     } finally {
       if (!secondDisposed) secondRequest.dispose()
       firstRequest.dispose()

--- a/packages/runtime/src/binding.ts
+++ b/packages/runtime/src/binding.ts
@@ -70,6 +70,7 @@ const REACTIVE_FN_MARKER = Symbol.for('fict:reactive-fn')
 const NON_REACTIVE_FN_REGISTRY_KEY = Symbol.for('fict:non-reactive-fn-registry')
 const REACTIVE_FN_REGISTRY_KEY = Symbol.for('fict:reactive-fn-registry')
 const PROP_GETTER_REGISTRY_KEY = Symbol.for('fict:prop-getter-registry')
+const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
 const DELEGATED_DATA_ONLY_MARKER = '__fictDataOnly'
 const DELEGATED_DATA_PLAIN_MARKER = '__fictDataOnlyPlain'
 
@@ -1132,6 +1133,20 @@ export function insert(
   let currentNodes: Node[] = []
   let currentText: Text | null = null
   let currentRoot: RootContext | null = null
+
+  const expectedMarker = (marker as Node & { [HYDRATED_TEMPLATE_NODE]?: Node })[
+    HYDRATED_TEMPLATE_NODE
+  ]
+  if (
+    __fictIsHydrating() &&
+    !ownsMarker &&
+    expectedMarker?.nodeType === 8 &&
+    expectedMarker.previousSibling === null &&
+    marker.previousSibling?.nodeType === 3
+  ) {
+    currentText = marker.previousSibling as Text
+    currentNodes = [currentText]
+  }
 
   const clearCurrentNodes = () => {
     const root = currentRoot

--- a/packages/runtime/src/binding.ts
+++ b/packages/runtime/src/binding.ts
@@ -24,7 +24,12 @@ import {
 import { isNodeLike } from './dom-guards'
 import { assertValidDOMAttributeName } from './dom-names'
 import { createRenderEffect } from './effect'
-import { withHydration, withHydrationRange, isHydratingActive } from './hydration'
+import {
+  HYDRATED_TEMPLATE_NODE,
+  withHydration,
+  withHydrationRange,
+  isHydratingActive,
+} from './hydration'
 import {
   createRootContext,
   deferRootRefAssignments,
@@ -70,7 +75,6 @@ const REACTIVE_FN_MARKER = Symbol.for('fict:reactive-fn')
 const NON_REACTIVE_FN_REGISTRY_KEY = Symbol.for('fict:non-reactive-fn-registry')
 const REACTIVE_FN_REGISTRY_KEY = Symbol.for('fict:reactive-fn-registry')
 const PROP_GETTER_REGISTRY_KEY = Symbol.for('fict:prop-getter-registry')
-const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
 const DELEGATED_DATA_ONLY_MARKER = '__fictDataOnly'
 const DELEGATED_DATA_PLAIN_MARKER = '__fictDataOnlyPlain'
 

--- a/packages/runtime/src/binding.ts
+++ b/packages/runtime/src/binding.ts
@@ -1079,6 +1079,24 @@ export function classList(
 // Child/Insert Binding (Dynamic Children)
 // ============================================================================
 
+function materializeArrayItems(
+  values: FictNode[],
+  createElementFn: CreateElementFn,
+  ownerDocument: Document,
+): Node[] {
+  const fragment = ownerDocument.createDocumentFragment()
+  for (const value of values) {
+    if (typeof value === 'function' && isReactive(value)) {
+      createChildBinding(fragment, value as () => FictNode, createElementFn)
+    } else {
+      for (const node of toNodeArray(createElementFn(value), ownerDocument)) {
+        fragment.appendChild(node)
+      }
+    }
+  }
+  return Array.from(fragment.childNodes)
+}
+
 /**
  * Insert reactive content into a parent element.
  * This is a simpler API than createChildBinding for basic cases.
@@ -1208,16 +1226,15 @@ export function insert(
           if (isNodeLike(value, ownerDocument)) {
             return value
           }
+          if (typeof value === 'function' && isReactive(value) && createFn) {
+            return materializeArrayItems([value], createFn, ownerDocument)
+          }
           if (Array.isArray(value)) {
             if (value.every(v => isNodeLike(v, ownerDocument))) {
               return value as Node[]
             }
             if (createFn) {
-              const mapped: Node[] = []
-              for (const item of value) {
-                mapped.push(...toNodeArray(createFn(item as any), ownerDocument))
-              }
-              return mapped
+              return materializeArrayItems(value, createFn, ownerDocument)
             }
             return ownerDocument.createTextNode(String(value))
           }
@@ -1431,16 +1448,15 @@ export function insertBetween(
           if (isNodeLike(value, ownerDocument)) {
             return value
           }
+          if (typeof value === 'function' && isReactive(value) && createElementFn) {
+            return materializeArrayItems([value], createElementFn, ownerDocument)
+          }
           if (Array.isArray(value)) {
             if (value.every(v => isNodeLike(v, ownerDocument))) {
               return value as Node[]
             }
             if (createElementFn) {
-              const mapped: Node[] = []
-              for (const item of value) {
-                mapped.push(...toNodeArray(createElementFn(item as any), ownerDocument))
-              }
-              return mapped
+              return materializeArrayItems(value, createElementFn, ownerDocument)
             }
             return ownerDocument.createTextNode(String(value))
           }
@@ -2345,16 +2361,15 @@ function bindAssignedChildren(
           if (isNodeLike(value, ownerDocument)) {
             return value
           }
+          if (typeof value === 'function' && isReactive(value) && createFn) {
+            return materializeArrayItems([value], createFn, ownerDocument)
+          }
           if (Array.isArray(value)) {
             if (value.every(v => isNodeLike(v, ownerDocument))) {
               return value as Node[]
             }
             if (createFn) {
-              const mapped: Node[] = []
-              for (const item of value) {
-                mapped.push(...toNodeArray(createFn(item as any), ownerDocument))
-              }
-              return mapped
+              return materializeArrayItems(value, createFn, ownerDocument)
             }
             return ownerDocument.createTextNode(String(value))
           }

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -782,12 +782,14 @@ function createElementWithContext(
  * @param isImportNode - Use importNode for elements like img/iframe
  * @param isSVG - Whether the template is SVG content
  * @param isMathML - Whether the template is MathML content
+ * @param forceFragment - Preserve the virtual JSX fragment root even when it has one child
  */
 export function template(
   html: string,
   isImportNode?: boolean,
   isSVG?: boolean,
   isMathML?: boolean,
+  forceFragment?: boolean,
 ): () => Node {
   const nodeByDocument = new WeakMap<Document, Node>()
 
@@ -803,7 +805,7 @@ export function template(
       if (isDev && wrapper.childNodes.length !== 1) {
         console.warn('[fict] Multi-root SVG template.')
       }
-      if (wrapper.childNodes.length === 1) {
+      if (!forceFragment && wrapper.childNodes.length === 1) {
         return wrapper.firstChild!
       }
       // Preserve all root nodes by returning a fragment
@@ -820,7 +822,7 @@ export function template(
       if (isDev && wrapper.childNodes.length !== 1) {
         console.warn('[fict] Multi-root MathML template.')
       }
-      if (wrapper.childNodes.length === 1) {
+      if (!forceFragment && wrapper.childNodes.length === 1) {
         return wrapper.firstChild!
       }
       // Preserve all root nodes by returning a fragment
@@ -835,7 +837,7 @@ export function template(
     if (isDev && content.childNodes.length !== 1) {
       console.warn('[fict] Multi-root template.')
     }
-    if (content.childNodes.length === 1) {
+    if (!forceFragment && content.childNodes.length === 1) {
       return content.firstChild!
     }
     // Preserve all root nodes by returning a fragment

--- a/packages/runtime/src/hydration.ts
+++ b/packages/runtime/src/hydration.ts
@@ -38,8 +38,7 @@ const isDev =
 const hydrationStack: HydrationContext[] = []
 let hydrationClaimSuppressionDepth = 0
 const HYDRATED_FRAGMENT_NODES = Symbol.for('fict:hydration-fragment-nodes')
-const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
-
+export const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
 type HydratedFragment = DocumentFragment & { [HYDRATED_FRAGMENT_NODES]?: Node[] }
 type HydratedTemplateNode = Node & { [HYDRATED_TEMPLATE_NODE]?: Node }
 

--- a/packages/runtime/src/hydration.ts
+++ b/packages/runtime/src/hydration.ts
@@ -38,8 +38,10 @@ const isDev =
 const hydrationStack: HydrationContext[] = []
 let hydrationClaimSuppressionDepth = 0
 const HYDRATED_FRAGMENT_NODES = Symbol.for('fict:hydration-fragment-nodes')
+const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
 
 type HydratedFragment = DocumentFragment & { [HYDRATED_FRAGMENT_NODES]?: Node[] }
+type HydratedTemplateNode = Node & { [HYDRATED_TEMPLATE_NODE]?: Node }
 
 interface HydrationRepairPlan {
   parent: ParentNode & Node
@@ -170,10 +172,18 @@ export function claimNodes(templateRoot: Node, fallback: () => Node): Node {
   ctx.cursor = cursor
 
   if (claimed.length === 1) {
-    return claimed[0]!
+    return attachHydrationTemplate(claimed[0]!, templateRoot)
   }
 
-  return createHydratedFragment(ctx.owner, claimed)
+  return attachHydrationTemplate(createHydratedFragment(ctx.owner, claimed), templateRoot)
+}
+
+function attachHydrationTemplate<T extends Node>(node: T, templateRoot: Node): T {
+  Object.defineProperty(node as HydratedTemplateNode, HYDRATED_TEMPLATE_NODE, {
+    configurable: true,
+    value: templateRoot,
+  })
+  return node
 }
 
 export function claimText(value: string, fallback: () => Text): Text {

--- a/packages/runtime/src/node-ops.ts
+++ b/packages/runtime/src/node-ops.ts
@@ -6,9 +6,11 @@
 import { isDocumentFragmentLike, isNodeLike } from './dom-guards'
 
 const HYDRATED_FRAGMENT_NODES = Symbol.for('fict:hydration-fragment-nodes')
+const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
 const DOCUMENT_FRAGMENT_NODE = 11
 
 type HydratedFragment = DocumentFragment & { [HYDRATED_FRAGMENT_NODES]?: Node[] }
+type HydratedTemplateNode = Node & { [HYDRATED_TEMPLATE_NODE]?: Node }
 
 function getHydratedFragmentNodes(node: Node): Node[] | undefined {
   if (node.nodeType !== DOCUMENT_FRAGMENT_NODE) return undefined
@@ -221,14 +223,77 @@ export function getSlotEnd(start: Comment): Comment {
 
 export function resolvePath(root: Node, path: number[]): Node | null {
   let current: Node | null = root
+  let expected: Node | null = (root as HydratedTemplateNode)[HYDRATED_TEMPLATE_NODE] ?? null
   for (const index of path) {
     if (!current) return null
-    current = getChildAtPathIndex(current, index)
+    current = expected
+      ? getHydratedChildAtPathIndex(current, expected, index)
+      : getChildAtPathIndex(current, index)
+    expected = expected ? getChildAtPathIndex(expected, index) : null
     if (!current) {
       return null
     }
   }
   return current
+}
+
+function getHydratedChildAtPathIndex(current: Node, expected: Node, index: number): Node | null {
+  const actualChildren = getLogicalChildren(current)
+  const expectedChildren = getLogicalChildren(expected)
+  let actualIndex = 0
+  for (let expectedIndex = 0; expectedIndex <= index; expectedIndex += 1) {
+    const expectedChild = expectedChildren[expectedIndex]
+    if (!expectedChild) return null
+    while (
+      actualIndex < actualChildren.length &&
+      !isHydrationPathCompatible(expectedChild, actualChildren[actualIndex]!)
+    ) {
+      actualIndex += 1
+    }
+    if (actualIndex >= actualChildren.length) return null
+    if (expectedIndex === index) {
+      return attachHydratedTemplateNode(actualChildren[actualIndex]!, expectedChild)
+    }
+    actualIndex += 1
+  }
+  return null
+}
+
+function attachHydratedTemplateNode(actual: Node, expected: Node): Node {
+  Object.defineProperty(actual as HydratedTemplateNode, HYDRATED_TEMPLATE_NODE, {
+    configurable: true,
+    value: expected,
+  })
+  return actual
+}
+
+function getLogicalChildren(current: Node): Node[] {
+  const childRoot = getTemplateContentRoot(current) ?? current
+  const children = getHydratedFragmentNodes(childRoot) ?? Array.from(childRoot.childNodes)
+  const logical: Node[] = []
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index]!
+    logical.push(child)
+    if (isSlotStart(child)) {
+      const endIndex = children.indexOf(getSlotEnd(child as Comment), index + 1)
+      if (endIndex !== -1) index = endIndex
+    }
+  }
+  return logical
+}
+
+function isHydrationPathCompatible(expected: Node, actual: Node): boolean {
+  if (expected.nodeType !== actual.nodeType) return false
+  if (expected.nodeType === 1) {
+    return (
+      (expected as Element).localName === (actual as Element).localName &&
+      (expected as Element).namespaceURI === (actual as Element).namespaceURI
+    )
+  }
+  if (expected.nodeType === 8) {
+    return (expected as Comment).data === (actual as Comment).data
+  }
+  return true
 }
 
 function getChildAtPathIndex(current: Node, index: number): Node | null {

--- a/packages/runtime/src/node-ops.ts
+++ b/packages/runtime/src/node-ops.ts
@@ -4,9 +4,9 @@
  */
 
 import { isDocumentFragmentLike, isNodeLike } from './dom-guards'
+import { HYDRATED_TEMPLATE_NODE } from './hydration'
 
 const HYDRATED_FRAGMENT_NODES = Symbol.for('fict:hydration-fragment-nodes')
-const HYDRATED_TEMPLATE_NODE = Symbol.for('fict:hydration-template-node')
 const DOCUMENT_FRAGMENT_NODE = 11
 
 type HydratedFragment = DocumentFragment & { [HYDRATED_FRAGMENT_NODES]?: Node[] }

--- a/packages/runtime/test/binding.test.ts
+++ b/packages/runtime/test/binding.test.ts
@@ -487,6 +487,41 @@ describe('Reactive DOM Binding', () => {
   })
 
   describe('insert', () => {
+    it('tracks a reactive accessor returned by the outer getter', async () => {
+      const child = createSignal({
+        type: 'span',
+        props: { children: 'first' },
+        key: undefined,
+      })
+      const root = createRoot(() => insert(container, () => child, createElement))
+
+      expect(container.textContent).toBe('first')
+      child({ type: 'span', props: { children: 'second' }, key: undefined })
+      await tick()
+      expect(container.textContent).toBe('second')
+
+      root.dispose()
+      expect(container.childNodes.length).toBe(0)
+    })
+
+    it('tracks reactive function items nested in arrays', async () => {
+      const value = createSignal('first')
+      const child = reactive(() => ({
+        type: 'span',
+        props: { children: value() },
+        key: undefined,
+      }))
+      const root = createRoot(() => insert(container, () => [child], createElement))
+
+      expect(container.textContent).toBe('first')
+      value('second')
+      await tick()
+      expect(container.textContent).toBe('second')
+
+      root.dispose()
+      expect(container.childNodes.length).toBe(0)
+    })
+
     it('cleans up fragment outputs and lifecycles when swapped', async () => {
       const show = createSignal(true)
       const cleanups: string[] = []

--- a/packages/runtime/test/dom.test.ts
+++ b/packages/runtime/test/dom.test.ts
@@ -2242,6 +2242,16 @@ describe('DOM Module', () => {
       expect((node2 as HTMLDivElement).className).toBe('test')
     })
 
+    it('preserves an explicit single-child fragment root', () => {
+      const factory = template('<!---->', undefined, undefined, undefined, true)
+
+      const node = factory()
+
+      expect(node).toBeInstanceOf(DocumentFragment)
+      expect(node.childNodes).toHaveLength(1)
+      expect(node.firstChild).toBeInstanceOf(Comment)
+    })
+
     it('caches the template element', () => {
       const factory = template('<span>Cached</span>')
 

--- a/packages/runtime/test/dom.test.ts
+++ b/packages/runtime/test/dom.test.ts
@@ -15,6 +15,7 @@ import {
   __fictSetComponentMeta,
   clearDelegatedEvents,
   hydrateComponent,
+  insert,
   resolvePath,
   spread,
   template,
@@ -423,6 +424,34 @@ describe('DOM Module', () => {
   })
 
   describe('hydrateComponent', () => {
+    it('aligns compiled marker paths past server-rendered dynamic text', async () => {
+      container.innerHTML =
+        '<section><span>US East<!----></span><strong>65<!---->%</strong></section>'
+      const label = createSignal('US East')
+      const capacity = createSignal(65)
+      const section = container.firstChild
+
+      const teardown = hydrateComponent(() => {
+        const root = template('<section><span><!----></span><strong><!---->%</strong></section>')()
+        const labelParent = resolvePath(root, [0])!
+        const labelMarker = resolvePath(root, [0, 0])!
+        const capacityParent = resolvePath(root, [1])!
+        const capacityMarker = resolvePath(root, [1, 0])!
+        insert(labelParent as ParentNode & Node, label, labelMarker)
+        insert(capacityParent as ParentNode & Node, capacity, capacityMarker)
+      }, container)
+
+      expect(container.firstChild).toBe(section)
+      expect(container.querySelector('span')?.textContent).toBe('US East')
+      expect(container.querySelector('strong')?.textContent).toBe('65%')
+
+      capacity(70)
+      await tick()
+
+      expect(container.querySelector('strong')?.textContent).toBe('70%')
+      teardown()
+    })
+
     it('claims matching nested resumable component hosts as opaque boundaries', () => {
       container.innerHTML =
         '<fict-host data-fict-host data-fict-s="sChild" data-fict-t="Child@test" data-fict-h="/child.js#resume"><button>1</button></fict-host>'

--- a/packages/ssr/test/e2e-resumable.test.ts
+++ b/packages/ssr/test/e2e-resumable.test.ts
@@ -36,7 +36,7 @@ import {
   serializeValue,
   deserializeValue,
 } from '@fictjs/runtime/internal'
-import createFictPlugin, { type FictCompilerOptions } from '../../compiler/src/index'
+import createFictPlugin, { type FictCompilerOptions } from '../../compiler/src/legacy'
 import { parseHTML } from 'linkedom'
 
 import {

--- a/packages/ssr/test/ssr-integration.test.ts
+++ b/packages/ssr/test/ssr-integration.test.ts
@@ -22,7 +22,7 @@ import {
   __fictDisableSSR,
   __fictIsSSR,
 } from '@fictjs/runtime/internal'
-import createFictPlugin, { type FictCompilerOptions } from '../../compiler/src/index'
+import createFictPlugin, { type FictCompilerOptions } from '../../compiler/src/legacy'
 import { parseHTML } from 'linkedom'
 
 import {

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -35,7 +35,7 @@ export default defineConfig({
       tsconfigPath: './tsconfig.json',
       // Optional plugin debug logs (or set FICT_VITE_PLUGIN_DEBUG=1)
       debug: false,
-      // Native compiler beta. The current compatibility-window default is 'legacy'.
+      // Optional override. Rust is the compatibility-window default.
       backend: 'rust',
       // Required for resumable builds only when no named package.json owns the Vite root
       // publicIdentityNamespace: 'com.example.my-app',
@@ -68,12 +68,11 @@ Custom Babel plugins must run as a separate stage; `@fictjs/babel-preset` is a
 deprecated legacy-only adapter and cannot mix Rust and Babel output in one
 build.
 
-## Native compiler beta and shadow mode
+## Native compiler default and shadow mode
 
-`backend` accepts `legacy`, `rust`, or `shadow`. The current beta keeps
-`legacy` as the default. `FICT_COMPILER_BACKEND` selects the same mode for a
-whole build when no explicit option is present; use
-`FICT_COMPILER_BACKEND=legacy` for rollback.
+`backend` accepts `legacy`, `rust`, or `shadow`. Rust is the default;
+`FICT_COMPILER_BACKEND` selects the same mode for a whole build when no
+explicit option is present. Use `FICT_COMPILER_BACKEND=legacy` for rollback.
 
 ```ts
 fict({

--- a/packages/vite-plugin/src/__tests__/cache-fingerprint.test.ts
+++ b/packages/vite-plugin/src/__tests__/cache-fingerprint.test.ts
@@ -161,6 +161,7 @@ async function transformWithFingerprints(
 
   const { default: fict } = await import('..')
   const plugin = fict({
+    backend: 'legacy',
     cache: {
       persistent: true,
       dir: cacheDir,
@@ -183,6 +184,7 @@ async function transformWithSplitMode(
 
   const { default: fict } = await import('..')
   const plugin = fict({
+    backend: 'legacy',
     functionSplitting: shouldSplit,
     cache: {
       persistent: true,

--- a/packages/vite-plugin/src/__tests__/decorators.test.ts
+++ b/packages/vite-plugin/src/__tests__/decorators.test.ts
@@ -5,7 +5,13 @@ import path from 'node:path'
 import { build, transformWithEsbuild } from 'vite'
 import { describe, expect, it, vi } from 'vitest'
 
-import fict from '..'
+import createFictVitePlugin from '..'
+
+function fict(
+  options?: Parameters<typeof createFictVitePlugin>[0],
+): ReturnType<typeof createFictVitePlugin> {
+  return createFictVitePlugin({ backend: 'legacy', ...options })
+}
 
 function createTransformPlugin(options: Parameters<typeof fict>[0] = {}) {
   const plugin = fict({

--- a/packages/vite-plugin/src/__tests__/dev-resumable-identity.test.ts
+++ b/packages/vite-plugin/src/__tests__/dev-resumable-identity.test.ts
@@ -7,7 +7,13 @@ import { fileURLToPath } from 'node:url'
 import { createServer, type ViteDevServer } from 'vite'
 import { describe, expect, it } from 'vitest'
 
-import fict, { __fictVitePluginInternals } from '..'
+import createFictVitePlugin, { __fictVitePluginInternals } from '..'
+
+function fict(
+  options?: Parameters<typeof createFictVitePlugin>[0],
+): ReturnType<typeof createFictVitePlugin> {
+  return createFictVitePlugin({ backend: 'legacy', ...options })
+}
 
 const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
 

--- a/packages/vite-plugin/src/__tests__/filter.test.ts
+++ b/packages/vite-plugin/src/__tests__/filter.test.ts
@@ -5,7 +5,13 @@ import path from 'node:path'
 import { build } from 'vite'
 import { describe, expect, it, vi } from 'vitest'
 
-import fict from '..'
+import createFictVitePlugin from '..'
+
+function fict(
+  options?: Parameters<typeof createFictVitePlugin>[0],
+): ReturnType<typeof createFictVitePlugin> {
+  return createFictVitePlugin({ backend: 'legacy', ...options })
+}
 
 function createTransformPlugin(options: Parameters<typeof fict>[0] = {}) {
   const plugin = fict({

--- a/packages/vite-plugin/src/__tests__/function-splitting-identity.test.ts
+++ b/packages/vite-plugin/src/__tests__/function-splitting-identity.test.ts
@@ -6,9 +6,15 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { build, type Rollup } from 'vite'
 import { describe, expect, it } from 'vitest'
 
-import fict, { __fictVitePluginInternals, registerExtractedHandler } from '..'
+import createFictVitePlugin, { __fictVitePluginInternals, registerExtractedHandler } from '..'
 import type { FictNode } from '../../../runtime/src/types'
 import { renderToString } from '../../../ssr/src/index'
+
+function fict(
+  options?: Parameters<typeof createFictVitePlugin>[0],
+): ReturnType<typeof createFictVitePlugin> {
+  return createFictVitePlugin({ backend: 'legacy', ...options })
+}
 
 interface BuildArtifact {
   fileName: string

--- a/packages/vite-plugin/src/__tests__/index.test.ts
+++ b/packages/vite-plugin/src/__tests__/index.test.ts
@@ -14,11 +14,11 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import { parse } from '@babel/parser'
-import { resolvePackageModuleMetadata } from '@fictjs/compiler'
+import { resolvePackageModuleMetadata } from '@fictjs/compiler/graph-host'
 import { build, createServer, resolveConfig, type Rollup, type TransformResult } from 'vite'
 import { describe, it, expect, vi } from 'vitest'
 
-import fict, { __fictVitePluginInternals } from '..'
+import createFictVitePlugin, { __fictVitePluginInternals } from '..'
 
 // Mock Vite config for testing
 const mockBuildConfig = {
@@ -33,6 +33,12 @@ const mockBuildConfig = {
 const mockSsrBuildConfig = {
   ...mockBuildConfig,
   build: { ssr: true },
+}
+
+function fict(
+  options?: Parameters<typeof createFictVitePlugin>[0],
+): ReturnType<typeof createFictVitePlugin> {
+  return createFictVitePlugin({ backend: 'legacy', ...options })
 }
 
 type TestPlugin = ReturnType<typeof fict> & {
@@ -5612,7 +5618,11 @@ describe('fict vite-plugin', () => {
     })
 
     it('preserves main-module sourcemaps when function splitting rewrites handlers', async () => {
-      const plugin = fict({ functionSplitting: true, resumable: true, sourcemap: true }) as any
+      const plugin = fict({
+        functionSplitting: true,
+        resumable: true,
+        sourcemap: true,
+      }) as any
 
       if (typeof plugin.configResolved === 'function') {
         plugin.configResolved(mockBuildConfig as any)
@@ -5655,7 +5665,11 @@ describe('fict vite-plugin', () => {
     })
 
     it('maps generated stack frame positions back to original TSX lines', async () => {
-      const plugin = fict({ functionSplitting: true, resumable: true, sourcemap: true }) as any
+      const plugin = fict({
+        functionSplitting: true,
+        resumable: true,
+        sourcemap: true,
+      }) as any
 
       if (typeof plugin.configResolved === 'function') {
         plugin.configResolved(mockBuildConfig as any)

--- a/packages/vite-plugin/src/__tests__/library-metadata-facade.test.ts
+++ b/packages/vite-plugin/src/__tests__/library-metadata-facade.test.ts
@@ -5,7 +5,13 @@ import path from 'node:path'
 import { build, type Rollup } from 'vite'
 import { describe, expect, it } from 'vitest'
 
-import fict from '..'
+import createFictVitePlugin from '..'
+
+function fict(
+  options?: Parameters<typeof createFictVitePlugin>[0],
+): ReturnType<typeof createFictVitePlugin> {
+  return createFictVitePlugin({ backend: 'legacy', ...options })
+}
 
 async function buildLibraryMetadata(root: string, entry: string): Promise<unknown[]> {
   const result = await build({

--- a/packages/vite-plugin/src/__tests__/native-backend.test.ts
+++ b/packages/vite-plugin/src/__tests__/native-backend.test.ts
@@ -148,11 +148,34 @@ describe('Rust compiler backend', () => {
     else process.env.FICT_COMPILER_BACKEND = originalCompilerBackend
   })
 
+  it('uses Rust as the whole-build default', async () => {
+    delete process.env.FICT_COMPILER_BACKEND
+    native.transform.mockResolvedValue(
+      compileResult({ code: 'export const selectedByDefault = true;\n' }),
+    )
+    const plugin = fict({
+      cache: false,
+      functionSplitting: false,
+      useTypeScriptProject: false,
+      publicIdentityNamespace: 'native-test@1',
+    })
+    plugin.configResolved?.(config as never)
+
+    const result = (await plugin.transform?.call(
+      context() as never,
+      'export const source = true',
+      '/project/src/default.ts',
+    )) as { code: string }
+
+    expect(result.code).toContain('selectedByDefault')
+    expect(native.transform).toHaveBeenCalledOnce()
+  })
+
   it('selects a whole-build backend from the environment below an explicit option', async () => {
     native.transform.mockResolvedValue(
-      compileResult({ code: 'export const selectedByEnvironment = true;\n' }),
+      compileResult({ code: 'export const selectedByExplicitOption = true;\n' }),
     )
-    process.env.FICT_COMPILER_BACKEND = 'rust'
+    process.env.FICT_COMPILER_BACKEND = 'legacy'
     const environmentPlugin = fict({
       cache: false,
       functionSplitting: false,
@@ -165,12 +188,12 @@ describe('Rust compiler backend', () => {
       'export const source = true',
       '/project/src/environment.ts',
     )) as { code: string }
-    expect(environmentResult.code).toContain('selectedByEnvironment')
-    expect(native.transform).toHaveBeenCalledOnce()
+    expect(environmentResult.code).toContain('source')
+    expect(environmentResult.code).not.toContain('selectedByExplicitOption')
+    expect(native.transform).not.toHaveBeenCalled()
 
-    native.transform.mockClear()
     const explicitPlugin = fict({
-      backend: 'legacy',
+      backend: 'rust',
       cache: false,
       functionSplitting: false,
       useTypeScriptProject: false,
@@ -182,9 +205,8 @@ describe('Rust compiler backend', () => {
       'export const source = true',
       '/project/src/explicit.ts',
     )) as { code: string }
-    expect(explicitResult.code).toContain('source')
-    expect(explicitResult.code).not.toContain('selectedByEnvironment')
-    expect(native.transform).not.toHaveBeenCalled()
+    expect(explicitResult.code).toContain('selectedByExplicitOption')
+    expect(native.transform).toHaveBeenCalledOnce()
   })
 
   it('fails closed for an unknown environment backend', () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -106,7 +106,7 @@ interface BabelGeneratorOptionsWithInputSourceMap extends BabelGeneratorOptions 
 export interface FictPluginOptions extends FictCompilerOptions {
   /**
    * Compiler implementation used by the Vite compile stage.
-   * @default 'legacy'
+   * @default 'rust'
    */
   backend?: FictCompilerBackend
   /** Shadow comparison controls. Used only with `backend: 'shadow'`. */
@@ -527,7 +527,7 @@ export default function fict(options: FictPluginOptions = {}): Plugin {
     ...compilerOptions
   } = options
   const backendFromEnvironment = process.env.FICT_COMPILER_BACKEND
-  const backend = (backendOption ?? backendFromEnvironment ?? 'legacy') as FictCompilerBackend
+  const backend = (backendOption ?? backendFromEnvironment ?? 'rust') as FictCompilerBackend
   if (backend !== 'legacy' && backend !== 'rust' && backend !== 'shadow') {
     throw new Error(`[fict] Unknown compiler backend ${JSON.stringify(backend)}.`)
   }

--- a/scripts/compiler-backend-bench.mjs
+++ b/scripts/compiler-backend-bench.mjs
@@ -98,7 +98,7 @@ async function runWorker() {
     const { transformSync } = require('../packages/compiler/node_modules/@babel/core')
     const transformTypeScript =
       require('../packages/compiler/node_modules/@babel/plugin-transform-typescript').default
-    const createFictPlugin = require('../packages/compiler/dist/index.cjs').default
+    const createFictPlugin = require('../packages/compiler/dist/legacy.cjs').default
     compile = (source, index) => {
       const result = transformSync(source, {
         filename: `/bench/module-${index}.tsx`,

--- a/scripts/fixtures/native-compiler-types/cjs.cts
+++ b/scripts/fixtures/native-compiler-types/cjs.cts
@@ -1,21 +1,21 @@
-import type {
-  AnalyzeRequest,
-  AnalyzeResult,
-  CompileRequest,
-  CompileResult,
-  ScanRequest,
-  ScanResult,
-} from '../../../packages/compiler/dist/index.cjs'
 import {
   analyze,
   analyzeSync,
-  createNativeCompilerFacade,
-  loadNativeCompilerBinding,
   nativeCompilerInfo,
   scan,
   scanSync,
   transform,
   transformSync,
+  type AnalyzeRequest,
+  type AnalyzeResult,
+  type CompileRequest,
+  type CompileResult,
+  type ScanRequest,
+  type ScanResult,
+} from '../../../packages/compiler/dist/index.cjs'
+import {
+  createNativeCompilerFacade,
+  loadNativeCompilerBinding,
   type NativeCompilerBinding,
   type NativeCompilerFacade,
 } from '../../../packages/compiler/dist/native-loader.cjs'

--- a/scripts/fixtures/native-compiler-types/esm.mts
+++ b/scripts/fixtures/native-compiler-types/esm.mts
@@ -1,21 +1,21 @@
-import type {
-  AnalyzeRequest,
-  AnalyzeResult,
-  CompileRequest,
-  CompileResult,
-  ScanRequest,
-  ScanResult,
-} from '../../../packages/compiler/dist/index.js'
 import {
   analyze,
   analyzeSync,
-  createNativeCompilerFacade,
-  loadNativeCompilerBinding,
   nativeCompilerInfo,
   scan,
   scanSync,
   transform,
   transformSync,
+  type AnalyzeRequest,
+  type AnalyzeResult,
+  type CompileRequest,
+  type CompileResult,
+  type ScanRequest,
+  type ScanResult,
+} from '../../../packages/compiler/dist/index.js'
+import {
+  createNativeCompilerFacade,
+  loadNativeCompilerBinding,
   type NativeCompilerBinding,
   type NativeCompilerFacade,
 } from '../../../packages/compiler/dist/native-loader.js'

--- a/scripts/hir-guardrails.mjs
+++ b/scripts/hir-guardrails.mjs
@@ -14,7 +14,7 @@ import { gzipSync } from 'zlib'
 const require = createRequire(import.meta.url)
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const compilerDistPath = path.join(__dirname, '../packages/compiler/dist/index.cjs')
+const compilerDistPath = path.join(__dirname, '../packages/compiler/dist/legacy.cjs')
 const baselinePath = path.join(__dirname, 'hir-guardrails.baseline.json')
 const updateBaseline = process.argv.includes('--update')
 

--- a/scripts/native-compiler-runtime.test.mjs
+++ b/scripts/native-compiler-runtime.test.mjs
@@ -10,7 +10,7 @@ import { pathToFileURL } from 'node:url'
 const require = createRequire(import.meta.url)
 const root = path.resolve(import.meta.dirname, '..')
 const { transformSync } = require('../packages/compiler/node_modules/@babel/core')
-const createFictPlugin = require('../packages/compiler/dist/index.cjs').default
+const createFictPlugin = require('../packages/compiler/dist/legacy.cjs').default
 const { JSDOM } = require('../packages/runtime/node_modules/jsdom')
 const binding = require(path.join(root, 'target', 'release', 'fict_compiler_napi.node'))
 

--- a/scripts/optimizer-bench.mjs
+++ b/scripts/optimizer-bench.mjs
@@ -207,7 +207,7 @@ function getBaselinePath(argv, fallbackPath) {
 function getFictPlugin() {
   if (createFictPlugin) return createFictPlugin
 
-  const modulePath = path.join(__dirname, '../packages/compiler/dist/index.cjs')
+  const modulePath = path.join(__dirname, '../packages/compiler/dist/legacy.cjs')
   const loaded = require(modulePath)
   createFictPlugin = loaded?.default ?? loaded
   if (typeof createFictPlugin !== 'function') {

--- a/scripts/package-tarball-smoke.mjs
+++ b/scripts/package-tarball-smoke.mjs
@@ -357,6 +357,7 @@ const nativeFacade = {
   }),
 }
 const originalLoad = Module._load
+delete process.env.FICT_COMPILER_BACKEND
 Module._load = function (request, parent, isMain) {
   if (request === '@fictjs/compiler/native') return nativeFacade
   if (forbidden.has(request)) throw new Error('Rust tarball path loaded ' + request)
@@ -367,7 +368,6 @@ Module._load = function (request, parent, isMain) {
   const viteModule = require('@fictjs/vite-plugin')
   const fict = viteModule.default ?? viteModule
   const plugin = fict({
-    backend: 'rust',
     functionSplitting: false,
     useTypeScriptProject: false,
     publicIdentityNamespace: 'tarball-test@1',

--- a/scripts/prepare-native-compiler-addon.mjs
+++ b/scripts/prepare-native-compiler-addon.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
 import path from 'node:path'
 
 import {
@@ -32,6 +32,10 @@ if (!sourceName) {
 }
 
 mkdirSync(path.dirname(destination), { recursive: true })
+// Replace the inode instead of overwriting an already-loaded Mach-O image. macOS
+// caches code-signing metadata by vnode and can otherwise reject the copied
+// add-on after a rebuild because its mtime no longer matches the cached image.
+rmSync(destination, { force: true })
 copyFileSync(path.join(releaseDirectory, sourceName), destination)
 const target = nativeHostTarget()
 const definition = nativeTargetDefinition(target)

--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -28,6 +28,12 @@ const rolloutState = JSON.parse(
 const rolloutReview = JSON.parse(
   readFileSync(new URL('../.github/compiler-rollout-review.json', import.meta.url), 'utf8'),
 )
+const rolloutEvidence = JSON.parse(
+  readFileSync(new URL('../.github/compiler-rollout-evidence.json', import.meta.url), 'utf8'),
+)
+const nativeCertification = JSON.parse(
+  readFileSync(new URL('../.github/compiler-native-certification.json', import.meta.url), 'utf8'),
+)
 const rolloutReadiness = readFileSync(
   new URL('./compiler-rollout-readiness.mjs', import.meta.url),
   'utf8',
@@ -246,7 +252,9 @@ test('Rust-default approval binds the complete native certification to its candi
   assert.equal(rolloutState.schemaVersion, 3)
   assert.equal(rolloutState.nativeCertificationPath, '.github/compiler-native-certification.json')
   assert.equal(rolloutReview.schemaVersion, 3)
-  assert.equal(rolloutReview.nativeCertificationDigest, null)
+  assert.equal(rolloutReview.status, 'approved')
+  assert.equal(rolloutReview.candidateDigest, rolloutEvidence.candidateDigest)
+  assert.equal(rolloutReview.nativeCertificationDigest, nativeCertification.certificationDigest)
   assert.match(rolloutReadiness, /assertNativeCertification\(nativeCertification, evidence\)/)
   assert.match(rolloutReadiness, /payload\.compilerBuildRevision !== evidence\.sourceRevision/)
   assert.match(rolloutReadiness, /payload\.compilerBuildId !== evidence\.compilerBuildId/)


### PR DESCRIPTION
## Summary

- bind the approved M7 rollout review to the retained candidate and native-certification digests
- expose the OXC/Rust serializable compiler API from `@fictjs/compiler` and make Rust the Vite default
- retain the complete Babel implementation at `@fictjs/compiler/legacy` for explicit whole-build rollback
- add the 0.29.0 minor changeset, migration guidance, package-boundary coverage, and default-path smoke tests

## Rollout approval

- reviewer: `unadlib`
- candidate: `sha256:6c032c65080833a69471ff73f1883e37e1a8b972e92f6b102b353183327fbc0f`
- native certification: `sha256:02c000c451daa29a4cf74c3ab70e4cd7448bc1adfd98f2013a29cf8ac9836a48`
- all nine review areas approved

## Verification

- `pnpm release:compiler:rust-rollout` — complete uninterrupted pass
- compiler: 2,906/2,906 tests
- Vite: 237/237 tests
- runtime parity: 32/32
- rollout state: 31/31
- release verification: 30/30
- tarball isolation smoke: 10 packages across ESM, CJS, non-Node ESM, and TypeScript consumers
- native Vite/Webpack/Playground/VS Code smoke, shadow comparison, and Rust-to-legacy whole-build rollback
- backend benchmark: p95 6.542x, median 6.515x, RSS 0.196x, raw 0.527x, gzip 0.528x

## Scope boundary

This promotes the Rust default for the planned 0.29.0 compatibility release. Legacy removal remains gated by the later M9 stability window, final legacy release, and a separate removal approval.
