### PR TITLE
fix(release): bypass proxies for local browser gates

### DIFF
--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -543,11 +543,29 @@ test('clean checkout reuses the content-addressed store without sharing installe
 })
 
 test('clean checkout isolates Turbo artifacts and uses CI browser behavior', () => {
-  assert.deepEqual(releaseIsolationEnv('/tmp/fict-clean', '/cache/pnpm'), {
+  assert.deepEqual(releaseIsolationEnv('/tmp/fict-clean', '/cache/pnpm', {}), {
     CI: 'true',
     FICT_PNPM_STORE_DIR: '/cache/pnpm',
     HUSKY: '0',
+    NO_PROXY: 'localhost,127.0.0.1,::1',
     TURBO_CACHE_DIR: '/tmp/fict-clean/.turbo/release-cache',
+    no_proxy: 'localhost,127.0.0.1,::1',
+  })
+})
+
+test('clean checkout preserves proxy exclusions while bypassing local browser servers', () => {
+  const environment = {
+    NO_PROXY: 'registry.npmjs.org,localhost',
+    no_proxy: 'internal.example,127.0.0.1',
+  }
+
+  assert.deepEqual(releaseIsolationEnv('/tmp/fict-clean', '/cache/pnpm', environment), {
+    CI: 'true',
+    FICT_PNPM_STORE_DIR: '/cache/pnpm',
+    HUSKY: '0',
+    NO_PROXY: 'registry.npmjs.org,localhost,internal.example,127.0.0.1,::1',
+    TURBO_CACHE_DIR: '/tmp/fict-clean/.turbo/release-cache',
+    no_proxy: 'registry.npmjs.org,localhost,internal.example,127.0.0.1,::1',
   })
 })
 

--- a/scripts/release-verify-clean.mjs
+++ b/scripts/release-verify-clean.mjs
@@ -43,12 +43,22 @@ export function pnpmStoreRoot(activeStorePath) {
   return /^v\d+$/.test(path.basename(normalized)) ? path.dirname(normalized) : normalized
 }
 
-export function releaseIsolationEnv(checkoutDir, sharedStoreDir) {
+const localNoProxyHosts = ['localhost', '127.0.0.1', '::1']
+
+export function releaseIsolationEnv(checkoutDir, sharedStoreDir, environment = process.env) {
+  const noProxy = [environment.NO_PROXY, environment.no_proxy, ...localNoProxyHosts]
+    .flatMap(value => value?.split(',') ?? [])
+    .map(value => value.trim())
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .join(',')
+
   return {
     CI: 'true',
     FICT_PNPM_STORE_DIR: sharedStoreDir,
     HUSKY: '0',
+    NO_PROXY: noProxy,
     TURBO_CACHE_DIR: path.join(checkoutDir, '.turbo', 'release-cache'),
+    no_proxy: noProxy,
   }
 }
 


### PR DESCRIPTION
## Summary

- preserve existing `NO_PROXY` / `no_proxy` exclusions in clean release verification
- always bypass proxies for `localhost`, `127.0.0.1`, and `::1`
- cover merged proxy exclusions with release-verification regression tests

## Verification

- `node --test scripts/release-verification.test.mjs` (33/33)
- `pnpm exec prettier --check scripts/release-verify-clean.mjs scripts/release-verification.test.mjs`
- `CI=true NODE_USE_ENV_PROXY=1 NO_PROXY=localhost,127.0.0.1,::1 no_proxy=localhost,127.0.0.1,::1 pnpm -C packages/fict test:e2e` (99/99)

This fixes Playwright treating an HTTP proxy's response for an unavailable localhost URL as an already-running web server during `release:verify:clean`.