### PR TITLE
chore(compiler): record 0.30.0 compatibility evidence

### DIFF
--- a/.github/compiler-consumer-evidence/v0.30.0.json
+++ b/.github/compiler-consumer-evidence/v0.30.0.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": 1,
+  "status": "pass",
+  "release": "0.30.0",
+  "repository": "https://github.com/fictjs/shadcn",
+  "defaultBranch": "main",
+  "commitSha": "adc6fcb33844d7f1f4439f9183ac3e295da7ec4a",
+  "workflow": {
+    "runId": "29449665346",
+    "runAttempt": "1",
+    "path": ".github/workflows/ci.yml",
+    "url": "https://github.com/fictjs/shadcn/actions/runs/29449665346",
+    "completedAt": "2026-07-15T20:53:15Z"
+  },
+  "project": {
+    "path": "apps/v4",
+    "name": "@fictjs/shadcn-v4-site",
+    "scripts": {
+      "build": "pnpm build:client && pnpm build:server",
+      "typecheck": "tsc --noEmit",
+      "verifyCompiler": "node scripts/verify-compiler.mjs"
+    }
+  },
+  "files": {
+    "manifest": {
+      "path": "apps/v4/package.json",
+      "digest": "sha256:825e24a573f77e7d4a63eeae23ac5670a7dec2f54404274d648ed6b7bc60500d"
+    },
+    "lockfile": {
+      "path": "apps/v4/pnpm-lock.yaml",
+      "digest": "sha256:d540e2260d798bcce46d6448eae49458c02ed86008faa9981cc8f393711545cf"
+    },
+    "viteConfig": {
+      "path": "apps/v4/vite.config.mjs",
+      "digest": "sha256:492ca42df647ab3e65ea0e33f62a9b465768f020707c0c116ffd1fad9c150318"
+    },
+    "verification": {
+      "path": "apps/v4/scripts/verify-compiler.mjs",
+      "digest": "sha256:d5dc19ec2c95e4547415beab02b2a16269c741a39c76e4cd6e522b8d11fbd094"
+    },
+    "workflow": {
+      "path": ".github/workflows/ci.yml",
+      "digest": "sha256:4ad228f3482d49848008a9cebf9343ddc585aeee9aabcd3603a4c87a05311116"
+    }
+  },
+  "packages": [
+    {
+      "name": "@fictjs/compiler",
+      "version": "0.30.0",
+      "integrity": "sha512-Qo11l1UUgiW6T2F/WloNYJ/eDpm0vVFu145f9YvrV2SbmYYciMAK7+ROtmoeDJuaNHGL5n0fECkd+XFqMJ7Eqg==",
+      "publishedAt": "2026-07-15T20:27:21.821Z"
+    },
+    {
+      "name": "@fictjs/runtime",
+      "version": "0.30.0",
+      "integrity": "sha512-REEaNgkeCo2gfzGxkhyfcCY2QJ+9wUAD1Gb/LcT93JqNhkQZs4Ulrhy6rcYQUFVj3AiGC/MC3k2s1FpBZbjb5Q==",
+      "publishedAt": "2026-07-15T20:27:30.484Z"
+    },
+    {
+      "name": "@fictjs/ssr",
+      "version": "0.28.2",
+      "integrity": "sha512-1fk18VPC32RzvF9xaRuIruEOLAbxEh4ahgfCSJBj0fOMMmpbXzvp8/o/+T/X9FtxUhOW3RmcJc/XtvQJRJvFfQ==",
+      "publishedAt": "2026-07-15T20:27:42.845Z"
+    },
+    {
+      "name": "@fictjs/vite-plugin",
+      "version": "0.30.0",
+      "integrity": "sha512-QWWjvq/jTTyR552vZozq0M//Wa9fo6TiP3a2Oa6MFrD51ScYoAXZexSX0E4FmpQwKXTzRWUkFmqR1b/+FtQZVw==",
+      "publishedAt": "2026-07-15T20:27:46.932Z"
+    },
+    {
+      "name": "fict",
+      "version": "0.30.0",
+      "integrity": "sha512-eFqkpW84bbNfFszgDiLkpwW7PH5q+gCukOLxOMHWtdg9hehKwhG7l70belxNX4sqFIzv02kucfV/rRytzoJusA==",
+      "publishedAt": "2026-07-15T20:27:56.239Z"
+    }
+  ],
+  "evidenceDigest": "sha256:1ec74c800d12a875368236303fb1685cdc5de5ebdc4d721ea39f2a6e8db98c83"
+}

--- a/.github/compiler-release-evidence/v0.30.0.json
+++ b/.github/compiler-release-evidence/v0.30.0.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "status": "pass",
+  "version": "0.30.0",
+  "tag": "v0.30.0",
+  "commitSha": "b804ffbbff84f5183f23473fb034188a8e8f3be9",
+  "workflowRunId": "29445934623",
+  "githubRelease": {
+    "id": 354692453,
+    "url": "https://github.com/fictjs/fict/releases/tag/v0.30.0",
+    "publishedAt": "2026-07-15T20:28:02Z",
+    "assets": [
+      {
+        "name": "native-certification.json",
+        "id": 478354578,
+        "size": 10007,
+        "digest": "sha256:472cb630b5d2e0f4043fe0886f38acb5d97a4c2627c65f6cb0e53c91505a6bc7"
+      },
+      {
+        "name": "npm-publish-plan.json",
+        "id": 478354580,
+        "size": 3405,
+        "digest": "sha256:09299a028442453ba777b744d308e07220d13e3565141fda903bd07e187ca220"
+      },
+      {
+        "name": "release-artifacts.json",
+        "id": 478354576,
+        "size": 5679,
+        "digest": "sha256:9fcf2c1e242b42cd06cc48478e6c6b91abac92e925788aafb6d1bb50a5a52d4f"
+      }
+    ]
+  },
+  "npm": {
+    "packageName": "@fictjs/compiler",
+    "version": "0.30.0",
+    "integrity": "sha512-Qo11l1UUgiW6T2F/WloNYJ/eDpm0vVFu145f9YvrV2SbmYYciMAK7+ROtmoeDJuaNHGL5n0fECkd+XFqMJ7Eqg==",
+    "provenance": true,
+    "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@fictjs%2fcompiler@0.30.0",
+    "publishedAt": "2026-07-15T20:27:21.821Z"
+  },
+  "evidenceDigest": "sha256:1fddc1a02ef29c0c5facb15315b6c748bcae1e0a20c6119701e88dba88b3acd4"
+}

--- a/.github/compiler-rollout-state.json
+++ b/.github/compiler-rollout-state.json
@@ -4,7 +4,7 @@
   "viteDefaultBackend": "rust",
   "rollbackBackend": "legacy",
   "rustDefaultRelease": "0.29.0",
-  "compatibilityRelease": null,
+  "compatibilityRelease": "0.30.0",
   "finalLegacyRelease": null,
   "legacyRemovalRelease": null,
   "candidateEvidencePath": ".github/compiler-rollout-evidence.json",


### PR DESCRIPTION
## Summary

- bind v0.30.0 to successful Release workflow 29445934623, the stable GitHub Release assets, npm integrity, and provenance
- bind the real fictjs/shadcn consumer at adc6fcb33844d7f1f4439f9183ac3e295da7ec4a to successful default-branch CI run 29449665346
- record 0.30.0 as the completed subsequent compatibility minor while retaining legacy rollback and a pending M9 review

## Verification

- pnpm release:evidence:compiler --version 0.30.0
- pnpm release:evidence:consumer --version 0.30.0 --repository fictjs/shadcn --commit adc6fcb33844d7f1f4439f9183ac3e295da7ec4a --workflow .github/workflows/ci.yml --project apps/v4
- pnpm test:compiler:rollout-state
- pnpm test:release-verification