### PR TITLE
chore(release): record 0.30.1 compiler publication

### DIFF
--- a/.github/compiler-release-evidence/v0.30.1.json
+++ b/.github/compiler-release-evidence/v0.30.1.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "status": "pass",
+  "version": "0.30.1",
+  "tag": "v0.30.1",
+  "commitSha": "8d4008929d46fc5f2c1e578423ff38ef95a5d084",
+  "workflowRunId": "29452739078",
+  "githubRelease": {
+    "id": 354740286,
+    "url": "https://github.com/fictjs/fict/releases/tag/v0.30.1",
+    "publishedAt": "2026-07-15T22:14:29Z",
+    "assets": [
+      {
+        "name": "native-certification.json",
+        "id": 478437552,
+        "size": 10007,
+        "digest": "sha256:81ab9a2bdc7e21d1bea13db29eea40b458fdaf0ae5e1dab8b78dab2fd30051a4"
+      },
+      {
+        "name": "npm-publish-plan.json",
+        "id": 478437554,
+        "size": 3405,
+        "digest": "sha256:d09bb075e6127700d0e6fc32c2b3c7ca263b47e42459397236cd8343c2951da6"
+      },
+      {
+        "name": "release-artifacts.json",
+        "id": 478437553,
+        "size": 5679,
+        "digest": "sha256:5eb91fd4d5d0b5f83c0b437dc31294791b8915e17df748c373991710ad332a1e"
+      }
+    ]
+  },
+  "npm": {
+    "packageName": "@fictjs/compiler",
+    "version": "0.30.1",
+    "integrity": "sha512-N7gzdPC9G9X8lD+0v7ClQl7v45T2Ep+DgdZgUJOuogkdTGqcBoofb+DJwKQ6IvCNmWCuujE7xbUrzhf/SI5ujA==",
+    "provenance": true,
+    "attestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/@fictjs%2fcompiler@0.30.1",
+    "publishedAt": "2026-07-15T22:13:43.753Z"
+  },
+  "evidenceDigest": "sha256:de4ba8141ae7b5d5cef78a8b92100a138706f11913aaeaf8ee31bab43ce6acbd"
+}


### PR DESCRIPTION
## Summary

- record immutable publication evidence for v0.30.1
- bind the tag commit, successful Release workflow, GitHub Release assets, npm integrity, and SLSA provenance
- leave compiler rollout state and the pending M9 removal review unchanged

## Verification

- Release workflow #29452739078: success
- 8 native targets x Node 22/24: success
- npm registry: 17/17 newly published packages verified with integrity and provenance
- clean npm consumer: Rust default revision, source map transform, /legacy, Babel preset, Vite, and Webpack entrypoints verified
- pnpm test:release-verification
- pnpm test:compiler:rollout-state
- pnpm exec prettier --check .github/compiler-release-evidence/v0.30.1.json